### PR TITLE
Conditionally include pid parameter in stream URL based on Acexy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ docker run -d \
   pipepito/acestream-scraper:latest
 ```
 
-The Acexy web interface will be available at `http://localhost:8080`.
+Acexy only exposes an status endpoint available at `http://localhost:8080/ace/status`.
 
 ### Using with External Acestream Engine
 
@@ -250,11 +250,17 @@ Get the M3U playlist for your media player:
 
 - Current playlist: `http://localhost:8000/playlist.m3u`
 - Force refresh: `http://localhost:8000/playlist.m3u?refresh=true`
+- Search channels: `http://localhost:8000/playlist.m3u?search=sports`
 
 To use in your media player (like VLC):
 1. Copy the playlist URL (http://localhost:8000/playlist.m3u)
 2. In your media player, select "Open Network Stream" or similar option
 3. Paste the URL and play
+
+**URL Formatting Note:**
+- When using Acexy proxy (port 8080), stream URLs are formatted as `{base_url}{channel_id}`
+- For all other configurations, `&pid={local_id}` is automatically appended to each stream URL: `{base_url}{channel_id}&pid={local_id}`
+- This ensures proper channel identification in various player environments
 
 ### API Documentation
 

--- a/app/services/playlist_service.py
+++ b/app/services/playlist_service.py
@@ -1,3 +1,4 @@
+import os
 from ..repositories import ChannelRepository
 from app.utils.config import Config
 
@@ -10,7 +11,16 @@ class PlaylistService:
         """Format stream URL based on base_url configuration."""
         # Get base_url directly from config instance
         base_url = getattr(self.config, 'base_url', 'acestream://')
-        return f'{base_url}{channel_id}&pid={local_id}'
+        
+        # Check if using Acexy (port 8080)
+        is_acexy_enabled = os.environ.get('ENABLE_ACEXY', 'false').lower() == 'true'
+        is_acexy_port = ':8080' in base_url
+        
+        # Don't add pid parameter if using Acexy
+        if is_acexy_enabled and is_acexy_port:
+            return f'{base_url}{channel_id}'
+        else:
+            return f'{base_url}{channel_id}&pid={local_id}'
 
     def _get_channels(self, search_term: str = None):
         """Retrieve channels from the repository with optional search term."""


### PR DESCRIPTION
Modify the stream URL formatting to conditionally include the pid parameter based on the Acexy settings, ensuring compatibility with the Acexy environment.