### PR TITLE
Automating Channel Data from EPG Guide

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -18,6 +18,7 @@ from app.api.controllers.health_controller import api as health_ns
 from app.api.controllers.playlist_controller import api as playlist_ns
 from app.api.controllers.warp_controller import api as warp_ns
 from app.api.controllers.search_controller import api as search_ns
+from app.api.controllers.epg_controller import api as epg_ns
 
 # Add namespaces to the API
 api.add_namespace(stats_ns, path='/stats')
@@ -28,6 +29,7 @@ api.add_namespace(health_ns, path='/health')
 api.add_namespace(playlist_ns, path='/playlists')
 api.add_namespace(warp_ns, path='/warp')
 api.add_namespace(search_ns, path='/search')
+api.add_namespace(epg_ns, path='/epg')
 
 # Register the config routes with the config namespace
 from . import config_routes

--- a/app/api/controllers/channels_controller.py
+++ b/app/api/controllers/channels_controller.py
@@ -33,7 +33,8 @@ channel_model = api.model('Channel', {
     'm3u_source': fields.String(description='Original M3U source'),
     'source_url': fields.String(description='Source URL for the channel'),
     'scraped_url_id': fields.String(description='ID of the scraped URL'),
-    'added_on': fields.DateTime(description='When the channel was added')
+    'added_on': fields.DateTime(description='When the channel was added'),
+    'epg_update_protected': fields.Boolean(description='Whether EPG mapping is locked for this channel')
 })
 
 status_check_result_model = api.model('StatusCheckResult', {
@@ -58,7 +59,9 @@ channel_update_model = api.model('ChannelUpdate', {
     'tvg_id': fields.String(description='TVG ID for EPG'),
     'tvg_name': fields.String(description='TVG Name for EPG'),
     'original_url': fields.String(description='Original URL before conversion'),
-    'm3u_source': fields.String(description='Original M3U source')
+    'm3u_source': fields.String(description='Original M3U source'),
+    'epg_update_protected': fields.Boolean(description='Whether EPG mapping is locked for this channel')
+
 })
 
 # Updated parser to include URL ID filter parameter
@@ -128,7 +131,7 @@ class ChannelList(Resource):
         
         # Serialize the results
         result = [channel.to_dict() for channel in channels]
-        
+
         return result
     
     @api.doc('create_channel')
@@ -239,6 +242,8 @@ class Channel(Resource):
                 channel.original_url = data['original_url']
             if 'm3u_source' in data:
                 channel.m3u_source = data['m3u_source']
+            if 'epg_update_protected' in data:
+                channel.epg_update_protected = bool(data['epg_update_protected'])
                 
             # Save changes
             channel_repo.commit()

--- a/app/api/controllers/epg_controller.py
+++ b/app/api/controllers/epg_controller.py
@@ -1,0 +1,199 @@
+from flask_restx import Namespace, Resource, fields
+from flask import request, jsonify
+import logging
+
+from app.models.epg_source import EPGSource
+from app.models.epg_string_mapping import EPGStringMapping
+from app.repositories.epg_source_repository import EPGSourceRepository
+from app.repositories.epg_string_mapping_repository import EPGStringMappingRepository
+from app.services.epg_service import EPGService
+
+logger = logging.getLogger(__name__)
+
+api = Namespace('epg', description='EPG configuration and management')
+
+# Models for API documentation
+epg_source_model = api.model('EPGSource', {
+    'id': fields.Integer(readonly=True, description='Unique ID for the source'),
+    'url': fields.String(required=True, description='URL of the EPG source (XMLTV)'),
+    'name': fields.String(description='Descriptive name for the source'),
+    'enabled': fields.Boolean(default=True, description='Whether this source is enabled'),
+    'last_updated': fields.DateTime(readonly=True, description='Last update timestamp'),
+    'error_count': fields.Integer(readonly=True, description='Error counter'),
+    'last_error': fields.String(readonly=True, description='Last error message')
+})
+
+epg_string_mapping_model = api.model('EPGStringMapping', {
+    'id': fields.Integer(readonly=True, description='Unique ID for the mapping'),
+    'search_pattern': fields.String(required=True, description='Text pattern to search in channel names'),
+    'epg_channel_id': fields.String(required=True, description='EPG channel ID to map to')
+})
+
+# Endpoints for EPG sources
+@api.route('/sources')
+class EPGSourceListResource(Resource):
+    @api.marshal_list_with(epg_source_model)
+    def get(self):
+        """Get all EPG sources"""
+        repo = EPGSourceRepository()
+        return repo.get_all()
+    
+    @api.expect(epg_source_model)
+    @api.marshal_with(epg_source_model, code=201)
+    def post(self):
+        """Add a new EPG source"""
+        data = request.json
+        repo = EPGSourceRepository()
+        
+        # Create new source
+        source = EPGSource(
+            url=data.get('url'),
+            name=data.get('name'),
+            enabled=data.get('enabled', True)
+        )
+        
+        repo.create(source)
+        return source, 201
+
+@api.route('/sources/<int:id>')
+class EPGSourceResource(Resource):
+    @api.marshal_with(epg_source_model)
+    def get(self, id):
+        """Get EPG source by ID"""
+        repo = EPGSourceRepository()
+        source = repo.get_by_id(id)
+        if not source:
+            api.abort(404, f"EPG source with ID {id} not found")
+        return source
+    
+    @api.expect(epg_source_model)
+    @api.marshal_with(epg_source_model)
+    def put(self, id):
+        """Update EPG source"""
+        data = request.json
+        repo = EPGSourceRepository()
+        
+        source = repo.get_by_id(id)
+        if not source:
+            api.abort(404, f"EPG source with ID {id} not found")
+        
+        if 'url' in data:
+            source.url = data['url']
+        if 'name' in data:
+            source.name = data['name']
+        if 'enabled' in data:
+            source.enabled = data['enabled']
+        
+        repo.update(source)
+        return source
+    
+    def delete(self, id):
+        """Delete EPG source"""
+        repo = EPGSourceRepository()
+        source = repo.get_by_id(id)
+        if not source:
+            api.abort(404, f"EPG source with ID {id} not found")
+        
+        repo.delete(source)
+        return {'message': f'EPG source {id} deleted'}, 200
+
+@api.route('/sources/<int:id>/toggle')
+class EPGSourceToggleResource(Resource):
+    @api.marshal_with(epg_source_model)
+    def post(self, id):
+        """Toggle enabled status for an EPG source"""
+        repo = EPGSourceRepository()
+        source = repo.get_by_id(id)
+        if not source:
+            api.abort(404, f"EPG source with ID {id} not found")
+        
+        repo.toggle_enabled(source)
+        return source
+
+# Endpoints for pattern mappings
+@api.route('/mappings')
+class EPGStringMappingListResource(Resource):
+    @api.marshal_list_with(epg_string_mapping_model)
+    def get(self):
+        """Get all pattern mappings"""
+        repo = EPGStringMappingRepository()
+        return repo.get_all()
+    
+    @api.expect(epg_string_mapping_model)
+    @api.marshal_with(epg_string_mapping_model, code=201)
+    def post(self):
+        """Add a new pattern mapping"""
+        data = request.json
+        repo = EPGStringMappingRepository()
+        
+        # Create new mapping
+        mapping = EPGStringMapping(
+            search_pattern=data.get('search_pattern'),
+            epg_channel_id=data.get('epg_channel_id')
+        )
+        
+        repo.create(mapping)
+        return mapping, 201
+
+@api.route('/mappings/<int:id>')
+class EPGStringMappingResource(Resource):
+    @api.marshal_with(epg_string_mapping_model)
+    def get(self, id):
+        """Get pattern mapping by ID"""
+        repo = EPGStringMappingRepository()
+        mapping = repo.get_by_id(id)
+        if not mapping:
+            api.abort(404, f"Mapping with ID {id} not found")
+        return mapping
+    
+    @api.expect(epg_string_mapping_model)
+    @api.marshal_with(epg_string_mapping_model)
+    def put(self, id):
+        """Update pattern mapping"""
+        data = request.json
+        repo = EPGStringMappingRepository()
+        
+        mapping = repo.get_by_id(id)
+        if not mapping:
+            api.abort(404, f"Mapping with ID {id} not found")
+        
+        if 'search_pattern' in data:
+            mapping.search_pattern = data['search_pattern']
+        if 'epg_channel_id' in data:
+            mapping.epg_channel_id = data['epg_channel_id']
+        
+        repo.update(mapping)
+        return mapping
+    
+    def delete(self, id):
+        """Delete pattern mapping"""
+        repo = EPGStringMappingRepository()
+        mapping = repo.get_by_id(id)
+        if not mapping:
+            api.abort(404, f"Mapping with ID {id} not found")
+        
+        repo.delete(mapping)
+        return {'message': f'Mapping {id} deleted'}, 200
+
+# Endpoints for EPG operations
+@api.route('/refresh')
+class EPGRefreshResource(Resource):
+    def post(self):
+        """Refresh EPG data from all sources"""
+        service = EPGService()
+        data = service.fetch_epg_data()
+        return {
+            'message': 'EPG data refreshed successfully',
+            'channels_found': len(data)
+        }
+
+@api.route('/update-channels')
+class EPGUpdateChannelsResource(Resource):
+    def post(self):
+        """Update all channels with EPG metadata"""
+        service = EPGService()
+        stats = service.update_all_channels()
+        return {
+            'message': 'Channel EPG update process completed',
+            'stats': stats
+        }

--- a/app/api/controllers/epg_controller.py
+++ b/app/api/controllers/epg_controller.py
@@ -217,11 +217,24 @@ class EPGChannelsResource(Resource):
         if not service.epg_data:
             service.fetch_epg_data()
         
-        # Convert to simple list of channel IDs and names
+        source_repo = EPGSourceRepository()
+        sources = {source.id: source for source in source_repo.get_all()}
+
+        # Sequential numbering of sources for UI display
+        source_numbers = {}
+        for i, source_id in enumerate(sources.keys()):
+            source_numbers[source_id] = f"Source #{i+1}"
+
+        # Convert to simple list of channel IDs and names with source info
         for channel_id, data in service.epg_data.items():
+            source_id = data.get('source_id')
+            source_name = source_numbers.get(source_id, "Unknown") if source_id else ""
+            
             channels.append({
                 'id': channel_id,
-                'name': data.get('tvg_name', channel_id)
+                'name': data.get('tvg_name', channel_id),
+                'source_id': source_id,
+                'source_name': source_name  
             })
         
         return channels

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,8 @@ from .acestream_channel import AcestreamChannel
 from .scraped_url import ScrapedURL
 from .settings import Setting
 from .url_types import BaseURL, ZeronetURL, RegularURL, create_url_object
+from .epg_source import EPGSource
+from .epg_string_mapping import EPGStringMapping
 
 __all__ = [
     'AcestreamChannel', 
@@ -10,5 +12,7 @@ __all__ = [
     'BaseURL', 
     'ZeronetURL', 
     'RegularURL', 
-    'create_url_object'
+    'create_url_object',
+    'EPGSource',
+    'EPGStringMapping'
 ]

--- a/app/models/acestream_channel.py
+++ b/app/models/acestream_channel.py
@@ -26,6 +26,7 @@ class AcestreamChannel(db.Model):
     is_online = db.Column(db.Boolean, default=False)
     last_checked = db.Column(db.DateTime)
     check_error = db.Column(db.Text)
+    epg_update_protected = db.Column(db.Boolean, default=False, nullable=False)
     
     def __repr__(self):
         return f'<AcestreamChannel {self.name or self.id}>'
@@ -52,5 +53,6 @@ class AcestreamChannel(db.Model):
             'tvg_id': self.tvg_id,
             'tvg_name': self.tvg_name,
             'original_url': self.original_url,
-            'm3u_source': self.m3u_source
+            'm3u_source': self.m3u_source,
+            'epg_update_protected': bool(self.epg_update_protected)
         }

--- a/app/models/epg_source.py
+++ b/app/models/epg_source.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from app.extensions import db
+
+class EPGSource(db.Model):
+    """Model for storing EPG guide URLs."""
+    __tablename__ = 'epg_sources'
+    
+    id = db.Column(db.Integer, primary_key=True)
+    url = db.Column(db.String(500), nullable=False)
+    name = db.Column(db.String(100), nullable=True)
+    enabled = db.Column(db.Boolean, default=True)
+    last_updated = db.Column(db.DateTime, default=datetime.utcnow)
+    error_count = db.Column(db.Integer, default=0)
+    last_error = db.Column(db.Text, nullable=True)
+    
+    def __repr__(self):
+        return f"<EPGSource {self.id}: {self.name or self.url}>"
+        
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'url': self.url,
+            'name': self.name,
+            'enabled': self.enabled,
+            'last_updated': self.last_updated.isoformat() if self.last_updated else None,
+            'error_count': self.error_count,
+            'last_error': self.last_error
+        }

--- a/app/models/epg_string_mapping.py
+++ b/app/models/epg_string_mapping.py
@@ -1,0 +1,19 @@
+from app.extensions import db
+
+class EPGStringMapping(db.Model):
+    """Model for mapping text patterns to EPG channel IDs."""
+    __tablename__ = 'epg_string_mappings'
+    
+    id = db.Column(db.Integer, primary_key=True)
+    search_pattern = db.Column(db.String(255), nullable=False, unique=True)
+    epg_channel_id = db.Column(db.String(255), nullable=False)
+    
+    def __repr__(self):
+        return f"<EPGStringMapping {self.id}: '{self.search_pattern}' -> {self.epg_channel_id}>"
+        
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'search_pattern': self.search_pattern,
+            'epg_channel_id': self.epg_channel_id
+        }

--- a/app/models/epg_string_mapping.py
+++ b/app/models/epg_string_mapping.py
@@ -7,6 +7,7 @@ class EPGStringMapping(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     search_pattern = db.Column(db.String(255), nullable=False, unique=True)
     epg_channel_id = db.Column(db.String(255), nullable=False)
+    is_exclusion = db.Column(db.Boolean, default=False)
     
     def __repr__(self):
         return f"<EPGStringMapping {self.id}: '{self.search_pattern}' -> {self.epg_channel_id}>"

--- a/app/repositories/epg_source_repository.py
+++ b/app/repositories/epg_source_repository.py
@@ -1,0 +1,45 @@
+from typing import List, Optional
+from datetime import datetime
+from app.models.epg_source import EPGSource
+from app.extensions import db
+
+class EPGSourceRepository:
+    def get_all(self) -> List[EPGSource]:
+        """Get all EPG sources."""
+        return EPGSource.query.all()
+    
+    def get_enabled(self) -> List[EPGSource]:
+        """Get all enabled EPG sources."""
+        return EPGSource.query.filter_by(enabled=True).all()
+    
+    def get_by_id(self, id: int) -> Optional[EPGSource]:
+        """Get EPG source by ID."""
+        return EPGSource.query.get(id)
+    
+    def create(self, source: EPGSource) -> EPGSource:
+        """Create a new EPG source."""
+        db.session.add(source)
+        db.session.commit()
+        return source
+    
+    def update(self, source: EPGSource) -> EPGSource:
+        """Update an existing EPG source."""
+        db.session.commit()
+        return source
+    
+    def delete(self, source: EPGSource) -> None:
+        """Delete an EPG source."""
+        db.session.delete(source)
+        db.session.commit()
+    
+    def toggle_enabled(self, source: EPGSource) -> EPGSource:
+        """Toggle enabled status of an EPG source."""
+        source.enabled = not source.enabled
+        db.session.commit()
+        return source
+    
+    def update_last_updated(self, source: EPGSource) -> EPGSource:
+        """Update last_updated timestamp."""
+        source.last_updated = datetime.utcnow()
+        db.session.commit()
+        return source

--- a/app/repositories/epg_string_mapping_repository.py
+++ b/app/repositories/epg_string_mapping_repository.py
@@ -1,0 +1,28 @@
+from typing import List, Optional
+from app.models.epg_string_mapping import EPGStringMapping
+from app.extensions import db
+
+class EPGStringMappingRepository:
+    def get_all(self) -> List[EPGStringMapping]:
+        """Get all string pattern mappings."""
+        return EPGStringMapping.query.all()
+    
+    def get_by_id(self, id: int) -> Optional[EPGStringMapping]:
+        """Get string mapping by ID."""
+        return EPGStringMapping.query.get(id)
+    
+    def create(self, mapping: EPGStringMapping) -> EPGStringMapping:
+        """Create a new string mapping."""
+        db.session.add(mapping)
+        db.session.commit()
+        return mapping
+    
+    def update(self, mapping: EPGStringMapping) -> EPGStringMapping:
+        """Update an existing string mapping."""
+        db.session.commit()
+        return mapping
+    
+    def delete(self, mapping: EPGStringMapping) -> None:
+        """Delete a string mapping."""
+        db.session.delete(mapping)
+        db.session.commit()

--- a/app/services/epg_service.py
+++ b/app/services/epg_service.py
@@ -1,0 +1,229 @@
+import requests
+import xml.etree.ElementTree as ET
+import logging
+from datetime import datetime
+from difflib import SequenceMatcher
+from typing import Dict, List, Optional, Tuple
+
+from app.models.acestream_channel import AcestreamChannel
+from app.models.epg_source import EPGSource
+from app.models.epg_string_mapping import EPGStringMapping
+from app.repositories.epg_source_repository import EPGSourceRepository
+from app.repositories.epg_string_mapping_repository import EPGStringMappingRepository
+from app.repositories.channel_repository import ChannelRepository
+from app.extensions import db
+
+logger = logging.getLogger(__name__)
+
+class EPGService:
+    def __init__(self):
+        self.epg_source_repo = EPGSourceRepository()
+        self.epg_string_mapping_repo = EPGStringMappingRepository()
+        self.channel_repo = ChannelRepository()
+        self.epg_data = {}  # Cache of EPG data {tvg_id: {tvg_name, logo}}
+        self.auto_mapping_threshold = 0.75  # Similarity threshold for auto-mapping
+    
+    def fetch_epg_data(self) -> Dict:
+        """Fetch EPG data from all enabled sources."""
+        self.epg_data = {}
+        sources = self.epg_source_repo.get_enabled()
+        
+        for source in sources:
+            try:
+                logger.info(f"Fetching EPG data from {source.url}")
+                response = requests.get(source.url, timeout=60)
+                if response.status_code == 200:
+                    self._parse_epg_xml(response.text)
+                    # Update timestamp
+                    source.last_updated = datetime.utcnow()
+                    source.error_count = 0
+                    source.last_error = None
+                else:
+                    error_msg = f"HTTP error {response.status_code}"
+                    logger.warning(f"Error fetching EPG from {source.url}: {error_msg}")
+                    source.error_count = source.error_count + 1 if source.error_count else 1
+                    source.last_error = error_msg
+            except Exception as e:
+                logger.error(f"Error processing EPG from {source.url}: {str(e)}")
+                source.error_count = source.error_count + 1 if source.error_count else 1
+                source.last_error = str(e)
+            
+            # Save changes to the source
+            self.epg_source_repo.update(source)
+        
+        logger.info(f"Loaded {len(self.epg_data)} channels from EPG sources")
+        return self.epg_data
+    
+    def _parse_epg_xml(self, xml_content: str) -> None:
+        """Parse EPG XML and extract channel information."""
+        try:
+            root = ET.fromstring(xml_content)
+            
+            # Extract channel information
+            for channel in root.findall(".//channel"):
+                channel_id = channel.get("id")
+                if not channel_id:
+                    continue
+                
+                display_name_elem = channel.find("display-name")
+                channel_name = display_name_elem.text if display_name_elem is not None else ""
+                
+                icon_elem = channel.find("icon")
+                icon_url = icon_elem.get("src") if icon_elem is not None else ""
+                
+                self.epg_data[channel_id] = {
+                    "tvg_id": channel_id,
+                    "tvg_name": channel_name,
+                    "logo": icon_url
+                }
+                
+        except Exception as e:
+            logger.error(f"Error parsing EPG XML: {str(e)}")
+            raise
+    
+    def get_channel_epg_data(self, channel: AcestreamChannel) -> Dict:
+        """
+        Get EPG data for a specific channel with the following priority:
+        1. Direct manual mapping in the channel table
+        2. String pattern mapping in EPGStringMapping
+        3. Automatic mapping by name similarity
+        """
+        # Ensure we have EPG data
+        if not self.epg_data:
+            self.fetch_epg_data()
+        
+        # 1. Check if it already has manual mapping in the table
+        if channel.tvg_id and channel.tvg_id in self.epg_data:
+            return self.epg_data[channel.tvg_id]
+        
+        # 2. Look for string pattern matches
+        string_mappings = self.epg_string_mapping_repo.get_all()
+        for mapping in string_mappings:
+            if mapping.search_pattern.lower() in channel.name.lower() and mapping.epg_channel_id in self.epg_data:
+                # Found a pattern match
+                return self.epg_data[mapping.epg_channel_id]
+        
+        # 3. Try automatic mapping by similarity
+        best_match = None
+        best_score = 0
+        
+        for epg_id, epg_data in self.epg_data.items():
+            score = SequenceMatcher(None, channel.name.lower(), epg_data["tvg_name"].lower()).ratio()
+            if score > best_score and score >= self.auto_mapping_threshold:
+                best_score = score
+                best_match = epg_id
+        
+        if best_match:
+            logger.info(f"Auto-mapped '{channel.name}' to '{self.epg_data[best_match]['tvg_name']}' (score: {best_score:.2f})")
+            return self.epg_data[best_match]
+        
+        # If no match, return basic information
+        return {
+            "tvg_id": "",
+            "tvg_name": channel.name,
+            "logo": ""
+        }
+    
+    def update_all_channels(self) -> Dict:
+        """
+        Update EPG metadata for all channels.
+        Returns update statistics.
+        """
+        # First load EPG data if not loaded
+        if not self.epg_data:
+            self.fetch_epg_data()
+        
+        if not self.epg_data:
+            return {"error": "No EPG data available", "updated": 0, "total": 0}
+        
+        # Get all active channels
+        channels = self.channel_repo.get_active()
+        updated_channels = 0
+        tvg_id_updates = 0
+        tvg_name_updates = 0
+        logo_updates = 0
+        
+        # For each channel, try to find and apply EPG data
+        for channel in channels:
+            updates = self._update_channel_epg(channel)
+            if updates[0]:  # If there was any update
+                updated_channels += 1
+                tvg_id_updates += 1 if updates[1] else 0
+                tvg_name_updates += 1 if updates[2] else 0
+                logo_updates += 1 if updates[3] else 0
+        
+        # Save changes to the database
+        db.session.commit()
+        
+        return {
+            "updated_channels": updated_channels,
+            "total_channels": len(channels),
+            "tvg_id_updates": tvg_id_updates,
+            "tvg_name_updates": tvg_name_updates,
+            "logo_updates": logo_updates
+        }
+    
+    def _update_channel_epg(self, channel: AcestreamChannel) -> Tuple[bool, bool, bool, bool]:
+        """
+        Update EPG data for a channel.
+        Returns a tuple of (updated, tvg_id_updated, tvg_name_updated, logo_updated)
+        """
+        updated = False
+        tvg_id_updated = False
+        tvg_name_updated = False
+        logo_updated = False
+        
+        # 1. Look for pattern mappings
+        string_mappings = self.epg_string_mapping_repo.get_all()
+        for mapping in string_mappings:
+            if mapping.search_pattern.lower() in channel.name.lower() and mapping.epg_channel_id in self.epg_data:
+                epg_data = self.epg_data[mapping.epg_channel_id]
+                updates = self._apply_epg_data(channel, epg_data)
+                
+                logger.info(f"Updated EPG for '{channel.name}' using pattern '{mapping.search_pattern}'")
+                return (True, *updates)
+        
+        # 2. Try automatic mapping by similarity
+        best_match = None
+        best_score = 0
+        
+        for epg_id, epg_data in self.epg_data.items():
+            score = SequenceMatcher(None, channel.name.lower(), epg_data["tvg_name"].lower()).ratio()
+            if score > best_score and score >= self.auto_mapping_threshold:
+                best_score = score
+                best_match = epg_id
+        
+        if best_match:
+            epg_data = self.epg_data[best_match]
+            updates = self._apply_epg_data(channel, epg_data)
+            
+            logger.info(f"Updated EPG for '{channel.name}' using similarity match '{epg_data['tvg_name']}' (score: {best_score:.2f})")
+            return (True, *updates)
+            
+        return (False, False, False, False)
+    
+    def _apply_epg_data(self, channel: AcestreamChannel, epg_data: Dict) -> Tuple[bool, bool, bool]:
+        """
+        Apply EPG data to the channel, respecting existing data.
+        Returns a tuple of (tvg_id_updated, tvg_name_updated, logo_updated).
+        """
+        tvg_id_updated = False
+        tvg_name_updated = False
+        logo_updated = False
+        
+        # Update tvg_id if it doesn't exist
+        if not channel.tvg_id and epg_data["tvg_id"]:
+            channel.tvg_id = epg_data["tvg_id"]
+            tvg_id_updated = True
+        
+        # Update tvg_name if it doesn't exist
+        if not channel.tvg_name and epg_data["tvg_name"]:
+            channel.tvg_name = epg_data["tvg_name"]
+            tvg_name_updated = True
+        
+        # Update logo if it doesn't exist
+        if not channel.logo and epg_data["logo"]:
+            channel.logo = epg_data["logo"]
+            logo_updated = True
+            
+        return (tvg_id_updated, tvg_name_updated, logo_updated)

--- a/app/services/epg_service.py
+++ b/app/services/epg_service.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime
 from difflib import SequenceMatcher
 from typing import Dict, List, Optional, Tuple
+import re
 
 from app.models.acestream_channel import AcestreamChannel
 from app.models.epg_source import EPGSource
@@ -33,7 +34,7 @@ class EPGService:
                 logger.info(f"Fetching EPG data from {source.url}")
                 response = requests.get(source.url, timeout=60)
                 if response.status_code == 200:
-                    self._parse_epg_xml(response.text)
+                    self._parse_epg_xml(response.text, source.id)  # Pass source.id
                     # Update timestamp
                     source.last_updated = datetime.utcnow()
                     source.error_count = 0
@@ -54,8 +55,7 @@ class EPGService:
         logger.info(f"Loaded {len(self.epg_data)} channels from EPG sources")
         return self.epg_data
     
-    def _parse_epg_xml(self, xml_content: str) -> None:
-        """Parse EPG XML and extract channel information."""
+    def _parse_epg_xml(self, xml_content: str, source_id: int) -> None:
         try:
             root = ET.fromstring(xml_content)
             
@@ -74,7 +74,8 @@ class EPGService:
                 self.epg_data[channel_id] = {
                     "tvg_id": channel_id,
                     "tvg_name": channel_name,
-                    "logo": icon_url
+                    "logo": icon_url,
+                    "source_id": source_id  # Store the source ID
                 }
                 
         except Exception as e:
@@ -124,106 +125,410 @@ class EPGService:
             "logo": ""
         }
     
-    def update_all_channels(self) -> Dict:
-        """
-        Update EPG metadata for all channels.
-        Returns update statistics.
-        """
-        # First load EPG data if not loaded
-        if not self.epg_data:
-            self.fetch_epg_data()
-        
-        if not self.epg_data:
-            return {"error": "No EPG data available", "updated": 0, "total": 0}
-        
-        # Get all active channels
-        channels = self.channel_repo.get_active()
-        updated_channels = 0
-        tvg_id_updates = 0
-        tvg_name_updates = 0
-        logo_updates = 0
-        
-        # For each channel, try to find and apply EPG data
-        for channel in channels:
-            updates = self._update_channel_epg(channel)
-            if updates[0]:  # If there was any update
-                updated_channels += 1
-                tvg_id_updates += 1 if updates[1] else 0
-                tvg_name_updates += 1 if updates[2] else 0
-                logo_updates += 1 if updates[3] else 0
-        
-        # Save changes to the database
-        db.session.commit()
-        
-        return {
-            "updated_channels": updated_channels,
-            "total_channels": len(channels),
-            "tvg_id_updates": tvg_id_updates,
-            "tvg_name_updates": tvg_name_updates,
-            "logo_updates": logo_updates
-        }
-    
     def _update_channel_epg(self, channel: AcestreamChannel) -> Tuple[bool, bool, bool, bool]:
         """
         Update EPG data for a channel.
-        Returns a tuple of (updated, tvg_id_updated, tvg_name_updated, logo_updated)
+        
+        Returns a tuple of (tvg_id_updated, tvg_name_updated, logo_updated, any_update)
         """
-        updated = False
-        tvg_id_updated = False
-        tvg_name_updated = False
-        logo_updated = False
-        
-        # 1. Look for pattern mappings
         string_mappings = self.epg_string_mapping_repo.get_all()
+        
+        # Detectar si el canal debe ser excluido (mantener esta parte sin cambios)
+        channel_name_lower = channel.name.lower()
         for mapping in string_mappings:
-            if mapping.search_pattern.lower() in channel.name.lower() and mapping.epg_channel_id in self.epg_data:
-                epg_data = self.epg_data[mapping.epg_channel_id]
-                updates = self._apply_epg_data(channel, epg_data)
+            if mapping.search_pattern.startswith('!'):
+                exclusion_pattern = mapping.search_pattern[1:].lower()
+                if exclusion_pattern in channel_name_lower:
+                    logger.info(f"Channel '{channel.name}' excluded by pattern '!{exclusion_pattern}'")
+                    
+                    # Limpiar los datos EPG si el canal tiene algún dato
+                    changes_made = False
+                    
+                    if channel.tvg_id:
+                        channel.tvg_id = None
+                        changes_made = True
+                    
+                    if channel.tvg_name:
+                        channel.tvg_name = None
+                        changes_made = True
+                    
+                    if channel.logo:
+                        channel.logo = None
+                        changes_made = True
+                    
+                    if changes_made:
+                        logger.info(f"Cleared EPG data from channel '{channel.name}' due to exclusion pattern")
+                        return (True, True, True, True)
+                    
+                    return (False, False, False, False)
+        
+        # Mejorar la lógica de mapeo
+        potential_mappings = []
+        
+        # Pre-procesar el nombre del canal para dividirlo en palabras para comparación más exacta
+        channel_words = channel_name_lower.split()
+        
+        for mapping in string_mappings:
+            if not mapping.search_pattern.startswith('!'):  # Solo procesar patrones regulares
+                pattern_lower = mapping.search_pattern.lower()
+                pattern_words = pattern_lower.split()
                 
-                logger.info(f"Updated EPG for '{channel.name}' using pattern '{mapping.search_pattern}'")
-                return (True, *updates)
+                # Solo considerar patrones que estén dentro del nombre del canal
+                if pattern_lower in channel_name_lower:
+                    # Base score - longitud del patrón multiplicado por 10 para darle más peso
+                    pattern_score = len(pattern_lower) * 10
+                    
+                    # MAYOR PRIORIDAD: Coincidencia exacta con el nombre completo
+                    if pattern_lower == channel_name_lower:
+                        pattern_score += 10000  # Prioridad extremadamente alta
+                    
+                    # NUEVA PRIORIDAD MUY ALTA: El patrón coincide exactamente con el inicio del nombre
+                    if channel_name_lower.startswith(pattern_lower):
+                        pattern_score += 3000  # Mayor prioridad que tener números
+                    
+                    # ALTA PRIORIDAD: Coincidencia al inicio del nombre (más importante que tener números)
+                    elif channel_name_lower.startswith(pattern_lower + ' '):
+                        pattern_score += 2500  # Mayor prioridad que tener números
+                    
+                    # Bonus por coincidencia de palabras completas
+                    matching_words = 0
+                    for word in pattern_words:
+                        if word in channel_words:
+                            matching_words += 1
+                    
+                    if matching_words == len(pattern_words):
+                        pattern_score += 1000 * matching_words
+                        
+                        # Bonus si las palabras están en el mismo orden
+                        if ' '.join(pattern_words) in ' '.join(channel_words):
+                            pattern_score += 500
+                    
+                    # Bonus para patrones con números (reducido para no sobrepasar coincidencias al inicio)
+                    if any(char.isdigit() for char in pattern_lower):
+                        pattern_score += 1500  # Reducido de 2000 a 1500
+                    
+                    # NUEVO: Bonus adicional si la primera palabra del patrón coincide con la primera palabra del canal
+                    # Esto ayuda a priorizar patrones como "dazn laliga" para canales que comienzan con "DAZN"
+                    if channel_words and pattern_words and channel_words[0] == pattern_words[0]:
+                        pattern_score += 1800
+                    
+                    potential_mappings.append((mapping, pattern_score))
         
-        # 2. Try automatic mapping by similarity
-        best_match = None
-        best_score = 0
+        # Ordenar por score, de mayor a menor
+        potential_mappings.sort(key=lambda x: x[1], reverse=True)
         
-        for epg_id, epg_data in self.epg_data.items():
-            score = SequenceMatcher(None, channel.name.lower(), epg_data["tvg_name"].lower()).ratio()
-            if score > best_score and score >= self.auto_mapping_threshold:
-                best_score = score
-                best_match = epg_id
-        
-        if best_match:
-            epg_data = self.epg_data[best_match]
-            updates = self._apply_epg_data(channel, epg_data)
+        # Usar el mapeo con el score más alto si existe
+        if potential_mappings:
+            best_mapping, score = potential_mappings[0]
             
-            logger.info(f"Updated EPG for '{channel.name}' using similarity match '{epg_data['tvg_name']}' (score: {best_score:.2f})")
-            return (True, *updates)
-            
+            if best_mapping.epg_channel_id in self.epg_data:
+                epg_data = self.epg_data[best_mapping.epg_channel_id]
+                updates = self._apply_epg_data(channel, epg_data)
+                if any(updates):
+                    logger.info(f"Channel '{channel.name}' matched pattern '{best_mapping.search_pattern}', applied EPG data from channel '{best_mapping.epg_channel_id}'")
+                return updates
+            else:
+                logger.warning(f"EPG channel ID '{best_mapping.epg_channel_id}' not found for pattern '{best_mapping.search_pattern}'")
+        
+        # Si no se encontró ningún mapeo adecuado
         return (False, False, False, False)
     
     def _apply_epg_data(self, channel: AcestreamChannel, epg_data: Dict) -> Tuple[bool, bool, bool]:
         """
-        Apply EPG data to the channel, respecting existing data.
+        Apply EPG data to the channel, always updating if the data exists in the EPG.
+        This overrides the previous behavior of only updating if the channel data was empty.
         Returns a tuple of (tvg_id_updated, tvg_name_updated, logo_updated).
         """
         tvg_id_updated = False
         tvg_name_updated = False
         logo_updated = False
         
-        # Update tvg_id if it doesn't exist
-        if not channel.tvg_id and epg_data["tvg_id"]:
+        # Update tvg_id if provided in EPG data (always update, not just when empty)
+        if epg_data["tvg_id"]:
+            # Only mark as updated if value actually changes
+            tvg_id_updated = channel.tvg_id != epg_data["tvg_id"]
             channel.tvg_id = epg_data["tvg_id"]
-            tvg_id_updated = True
         
-        # Update tvg_name if it doesn't exist
-        if not channel.tvg_name and epg_data["tvg_name"]:
+        # Update tvg_name if provided in EPG data
+        if epg_data["tvg_name"]:
+            tvg_name_updated = channel.tvg_name != epg_data["tvg_name"]
             channel.tvg_name = epg_data["tvg_name"]
-            tvg_name_updated = True
         
-        # Update logo if it doesn't exist
-        if not channel.logo and epg_data["logo"]:
+        # Update logo if provided in EPG data
+        if epg_data["logo"]:
+            logo_updated = channel.logo != epg_data["logo"]
             channel.logo = epg_data["logo"]
-            logo_updated = True
             
         return (tvg_id_updated, tvg_name_updated, logo_updated)
+    
+    def update_all_channels_epg(self, respect_existing: bool = False, clean_unmatched: bool = False) -> dict:
+        """
+        Updates EPG information for all channels that don't have EPG locked.
+        
+        Args:
+            respect_existing: If True, don't modify channels that already have some EPG data
+            clean_unmatched: If True, clear EPG data from channels with no match
+        
+        Returns:
+            Stats about the update process.
+        """
+        stats = {
+            "total": 0,
+            "updated": 0,
+            "locked": 0,
+            "excluded": 0,
+            "cleaned": 0,
+            "skipped": 0,
+            "errors": 0
+        }
+        
+        # Verificar si hay reglas de mapeo definidas
+        string_mappings = self.epg_string_mapping_repo.get_all()
+        normal_rules = [m for m in string_mappings if not m.search_pattern.startswith('!')]
+        has_mapping_rules = len(normal_rules) > 0
+        
+        logger.info(f"Updating EPG mappings. Has mapping rules: {has_mapping_rules}, Normal rules count: {len(normal_rules)}")
+        
+        channels = self.channel_repo.get_all()
+        channels_with_epg = [c for c in channels if c.tvg_id or c.tvg_name or c.logo]
+        
+        logger.info(f"Processing {len(channels)} channels, {len(channels_with_epg)} have some EPG data")
+        stats["total"] = len(channels)
+        
+        # Primero asegurarnos de cargar los datos EPG
+        if not self.epg_data:
+            self.fetch_epg_data()
+        
+        # Usar una transacción explícita para asegurar que los cambios se apliquen
+        from sqlalchemy.orm import Session
+        session = db.session
+        
+        try:
+            for channel in channels:
+                try:
+                    # Cambiar epg_update_protected por epg_update_protected
+                    if channel.epg_update_protected:
+                        stats["locked"] += 1
+                        continue
+                    
+                    # Si la opción respect_existing está activada y el canal ya tiene datos, saltarlo
+                    if respect_existing and (channel.tvg_id or channel.tvg_name or channel.logo):
+                        stats["skipped"] += 1
+                        continue
+                    
+                    if not has_mapping_rules:
+                        # Si no hay reglas de mapeo y el canal tiene datos, limpiarlo SOLO si clean_unmatched es true
+                        if clean_unmatched and (channel.tvg_id or channel.tvg_name or channel.logo):
+                            old_data = f"tvg_id={channel.tvg_id}, tvg_name={channel.tvg_name}, logo={'Yes' if channel.logo else 'No'}"
+                            
+                            # Realizar limpieza directamente
+                            channel.tvg_id = None
+                            channel.tvg_name = None
+                            channel.logo = None
+                            
+                            # Actualizar el canal en la base de datos
+                            try:
+                                self.channel_repo.update(channel)
+                                session.flush()
+                                
+                                stats["cleaned"] += 1
+                                logger.info(f"CLEANED: Channel '{channel.name}' (previous: {old_data}) - no mapping rules exist")
+                            except Exception as e:
+                                logger.error(f"Failed to update channel {channel.name}: {str(e)}")
+                                stats["errors"] += 1
+                        continue
+                    
+                    # Si hay reglas, proceder con la aplicación de mapeos
+                    was_updated, tvg_id_updated, tvg_name_updated, logo_updated = self._update_channel_epg(channel)
+                    
+                    if was_updated:
+                        try:
+                            self.channel_repo.update(channel)
+                            session.flush()  # Asegurar que los cambios se apliquen
+                            
+                            if not channel.tvg_id and not channel.tvg_name and not channel.logo:
+                                stats["cleaned"] += 1
+                                stats["excluded"] += 1
+                                logger.info(f"EXCLUDED: Channel '{channel.name}' matched exclusion rule")
+                            else:
+                                stats["updated"] += 1
+                                logger.info(f"UPDATED: Channel '{channel.name}' with new EPG data")
+                        except Exception as e:
+                            logger.error(f"Failed to save updates for channel {channel.name}: {str(e)}")
+                            stats["errors"] += 1
+                        continue
+                    
+                    # Si no se actualizó el canal y no está excluido, limpiar sus datos
+                    is_excluded = self._is_excluded_by_rule(channel)
+                    
+                    if not is_excluded and (channel.tvg_id or channel.tvg_name or channel.logo):
+                        # CORRECCIÓN: Limpiar solo si clean_unmatched es verdadero
+                        if clean_unmatched:
+                            old_data = f"tvg_id={channel.tvg_id}, tvg_name={channel.tvg_name}, logo={'Yes' if channel.logo else 'No'}"
+                            
+                            # Limpiar datos
+                            channel.tvg_id = None
+                            channel.tvg_name = None
+                            channel.logo = None
+                            
+                            try:
+                                self.channel_repo.update(channel)
+                                session.flush()
+                                
+                                stats["cleaned"] += 1
+                                logger.info(f"CLEANED: Channel '{channel.name}' (previous: {old_data}) - no matching rule")
+                            except Exception as e:
+                                logger.error(f"Failed to clean channel {channel.name}: {str(e)}")
+                                stats["errors"] += 1
+                    elif is_excluded:
+                        stats["excluded"] += 1
+                    
+                except Exception as e:
+                    logger.error(f"Error processing channel {channel.name}: {str(e)}")
+                    stats["errors"] += 1
+            
+            # Confirmar todos los cambios
+            session.commit()
+            logger.info(f"EPG update completed. Summary: Updated={stats['updated']}, Cleaned={stats['cleaned']}, Locked={stats['locked']}, Excluded={stats['excluded']}, Errors={stats['errors']}")
+        
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Transaction failed, rolling back: {str(e)}")
+            stats["errors"] += 1
+            raise
+                
+        return stats
+    
+    def _is_excluded_by_rule(self, channel: AcestreamChannel) -> bool:
+        """Determinar si un canal está excluido por una regla de patrón."""
+        channel_name_lower = channel.name.lower()
+        string_mappings = self.epg_string_mapping_repo.get_all()
+        
+        for mapping in string_mappings:
+            if mapping.search_pattern.startswith('!'):
+                exclusion_pattern = mapping.search_pattern[1:].lower()
+                if exclusion_pattern in channel_name_lower:
+                    return True
+        
+        return False
+
+    def auto_scan_channels(self, threshold: float = 0.8, clean_unmatched: bool = False, respect_existing: bool = False) -> dict:
+        """
+        Scan all unlocked channels and try to match them with EPG data.
+        
+        Args:
+            threshold: Similarity threshold for matching (0.0-1.0)
+            clean_unmatched: If True, clear EPG data from channels with no match
+            respect_existing: If True, don't modify channels that already have some EPG data
+        
+        Returns:
+            Statistics about the scan
+        """
+        # Ensure we have EPG data
+        if not self.epg_data:
+            self.fetch_epg_data()
+        
+        channels = self.channel_repo.get_all()
+        
+        total_processed = 0
+        total_matched = 0
+        total_cleaned = 0
+        total_skipped = 0
+        
+        for channel in channels:
+            if channel.epg_update_protected:
+                continue
+                
+            # Skip channels excluded by rules
+            if self._is_excluded_by_rule(channel):
+                continue
+            
+            # Skip channels that already have EPG data if respect_existing is enabled
+            if respect_existing and (channel.tvg_id or channel.tvg_name or channel.logo):
+                total_skipped += 1
+                continue
+            
+            # Skip channels with complete EPG data
+            if channel.tvg_id and channel.tvg_name and channel.logo:
+                continue
+                
+            total_processed += 1
+            
+            # Try to find best match by name similarity using normalized names
+            best_match = None
+            best_score = 0
+            normalized_channel_name = self._normalize_channel_name(channel.name)
+            
+            for epg_id, epg_data in self.epg_data.items():
+                normalized_epg_name = self._normalize_channel_name(epg_data["tvg_name"])
+                
+                # Usar nombres normalizados para la comparación
+                score = SequenceMatcher(None, normalized_channel_name, normalized_epg_name).ratio()
+                
+                # Dar bonus si el inicio del nombre coincide exactamente
+                if normalized_epg_name.startswith(normalized_channel_name) or normalized_channel_name.startswith(normalized_epg_name):
+                    score += 0.1  # Bonus for matching prefix
+                
+                if score > best_score and score >= threshold:
+                    best_score = score
+                    best_match = epg_id
+            
+            if best_match:
+                epg_data = self.epg_data[best_match]
+                updates = self._apply_epg_data(channel, epg_data)
+                if any(updates):
+                    logger.info(f"Auto-mapped '{channel.name}' to '{epg_data['tvg_name']}' (score: {best_score:.2f}, normalized: '{normalized_channel_name}')")
+                    self.channel_repo.update(channel)
+                    total_matched += 1
+            elif clean_unmatched and (channel.tvg_id or channel.tvg_name or channel.logo):
+                # Clean EPG data if no match was found and clean_unmatched is enabled
+                old_data = f"tvg_id={channel.tvg_id}, tvg_name={channel.tvg_name}, logo={'Yes' if channel.logo else 'No'}"
+                channel.tvg_id = None
+                channel.tvg_name = None
+                channel.logo = None
+                self.channel_repo.update(channel)
+                total_cleaned += 1
+                logger.info(f"Cleaned EPG data from channel '{channel.name}' (previous: {old_data}) - no match found")
+        
+        # Save all changes
+        db.session.commit()
+        
+        return {
+            'total': total_processed,
+            'matched': total_matched,
+            'cleaned': total_cleaned,
+            'skipped': total_skipped
+        }
+
+    def _normalize_channel_name(self, channel_name: str) -> str:
+        """
+        Normaliza el nombre del canal eliminando indicadores de calidad y términos técnicos
+        que no son relevantes para la comparación con EPG.
+        """
+        # Convertir a minúsculas
+        name = channel_name.lower()
+        
+        # Eliminar todo lo que esté entre paréntesis
+        name = re.sub(r'\([^)]*\)', '', name)
+        
+        # Eliminar términos técnicos comunes
+        terms_to_remove = [
+            '1080', '1080p', '720', '480', '4k', '8k',
+            'hd', 'sd', 'uhd', 'fullhd', 'full hd', 
+            'multiaudio', 'multi audio', 'multilenguaje', 'multi', 
+            'p', 'i', 'h264', 'h265', 'hevc',
+            'ace', 'acestream', 
+            '+', '[]', '()', '{}',
+        ]
+        
+        for term in terms_to_remove:
+            # Reemplazar el término rodeado por espacios, al principio o al final
+            name = re.sub(r'(^|\s)' + re.escape(term) + r'(\s|$)', ' ', name)
+        
+        # Eliminar múltiples espacios
+        name = re.sub(r'\s+', ' ', name)
+        
+        # Eliminar espacios al principio y al final
+        name = name.strip()
+        
+        return name

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -235,113 +235,16 @@ async function searchChannels(searchTerm, urlId = '') {
         // Fetch filtered channels
         const queryString = params.toString() ? `?${params.toString()}` : '';
         const response = await fetch(`/api/channels${queryString}`);
+        const data = await response.json();
         
         if (!response.ok) {
-            const data = await response.json();
             throw new Error(data.message || 'Failed to search channels');
         }
         
-        const channels = await response.json();
-        
-        // Update the channel list with the same styling as refreshChannelList
-        const channelsList = document.getElementById('channelsList');
-        if (channelsList) {
-            channelsList.innerHTML = channels.map(channel => {
-                // Asegurarse de que channel.id y channel.name nunca sean null
-                const channelId = channel.id || 'unknown';
-                const channelName = channel.name || 'Unnamed Channel';
-                
-                // Determinar clase de estilo según metadatos
-                let metadataClass = 'primary'; // Por defecto azul (sin metadatos)
-                let metadataText = 'Basic';
-                let metadataBadge = '';
-                let tooltipText = 'Edit channel - No EPG data';
-                
-                // Si está bloqueado, tiene prioridad en el color
-                if (channel.epg_update_protected) {
-                    metadataClass = 'purple';
-                    metadataText = 'Locked EPG';
-                    metadataBadge = '<span class="badge bg-purple ms-1"><i class="bi bi-lock-fill"></i></span>';
-                    tooltipText = 'Edit channel - EPG locked (protected from automatic updates)';
-                }
-                // Sino evaluamos el estado de los metadatos
-                else if (channel.tvg_id && channel.tvg_name && channel.logo) {
-                    metadataClass = 'success';  // Verde - completo
-                    metadataText = 'Complete EPG';
-                    tooltipText = 'Edit channel - Complete EPG data';
-                } 
-                else if (channel.tvg_id || channel.tvg_name || channel.logo) {
-                    metadataClass = 'warning';  // Ámbar - parcial
-                    metadataText = 'Partial EPG';
-                    tooltipText = 'Edit channel - Partial EPG data';
-                }
-                
-                // Logo display
-                const logoHtml = channel.logo ? 
-                    `<img src="${channel.logo}" alt="Logo" class="channel-logo me-2" style="max-height:60px; max-width:60px;">` : 
-                    '';
-                
-                // Usar exactamente el mismo HTML que en refreshChannelList
-                return `
-                <tr class="border-${metadataClass}">
-                    <td>
-                        <div class="d-flex align-items-center">
-                            ${logoHtml}
-                            <div>
-                                ${channelName}
-                                <span class="badge bg-${metadataClass} ms-1">${metadataText}</span>
-                                ${metadataBadge}
-                            </div>
-                        </div>
-                    </td>
-                    <td>
-                        <a href="acestream://${channelId}" class="text-decoration-none" title="Open in Acestream player">
-                            ${channelId}
-                        </a>
-                    </td>
-                    <td>
-                        ${formatLocalDate(channel.last_processed)}
-                        ${channel.last_checked ? `
-                            <br>
-                            <small class="text-muted">
-                                Status: <span class="badge ${channel.is_online ? 'bg-success' : 'bg-danger'}">
-                                    ${channel.is_online ? 'Online' : 'Offline'}
-                                </span>
-                                ${channel.check_error ? `<br><small class="text-danger">Error: ${channel.check_error}</small>` : ''}
-                                <br>
-                                Last checked: ${formatLocalDate(channel.last_checked)}
-                            </small>
-                        ` : ''}
-                    </td>
-                    <td>
-                        <div class="btn-group">
-                            <button class="btn btn-sm btn-${channel.epg_update_protected ? 'purple' : 'outline-secondary'} toggle-epg-lock" 
-                                data-id="${channelId}" title="${channel.epg_update_protected ? 'Allow automatic EPG updates' : 'Prevent automatic EPG updates'}">
-                                ${channel.epg_update_protected ? '<i class="bi bi-lock-fill"></i>' : '<i class="bi bi-unlock"></i>'} EPG
-                            </button>
-                            <button class="btn btn-sm btn-info check-status" 
-                                onclick="checkChannelStatus('${encodeURIComponent(channelId)}')" title="Check status">
-                                <i class="bi bi-shield-check"></i>
-                            </button>
-                            <button class="btn btn-sm btn-${metadataClass} edit-channel" 
-                                onclick="editChannel('${encodeURIComponent(channelId)}')" title="${tooltipText}">
-                                <i class="bi bi-pencil"></i>
-                            </button>
-                            <button class="btn btn-sm btn-danger" 
-                                onclick="deleteChannel('${encodeURIComponent(channelId)}')" title="Delete channel">
-                                <i class="bi bi-trash"></i>
-                            </button>
-                        </div>
-                    </td>
-                </tr>
-                `;
-            }).join('');
-        }
-        
-        return channels;
+        return data;
     } catch (error) {
         console.error('Error searching channels:', error);
-        showAlert('danger', 'Error searching channels');
+        showAlert('error', 'Error searching channels');
         return [];
     } finally {
         hideLoading();

--- a/app/static/js/channels.js
+++ b/app/static/js/channels.js
@@ -278,7 +278,7 @@ async function searchChannels(searchTerm, urlId = '') {
                 
                 // Logo display
                 const logoHtml = channel.logo ? 
-                    `<img src="${channel.logo}" alt="Logo" class="channel-logo me-2" style="max-height:24px; max-width:50px;">` : 
+                    `<img src="${channel.logo}" alt="Logo" class="channel-logo me-2" style="max-height:60px; max-width:60px;">` : 
                     '';
                 
                 // Usar exactamente el mismo HTML que en refreshChannelList

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -421,9 +421,39 @@ function updateChannelList(channels) {
         return;
     }
     
-    channelsList.innerHTML = channels.map(channel => `
+    channelsList.innerHTML = channels.map(channel => {
+        // Determine metadata styling based on EPG data completeness
+        let metadataClass = 'primary'; // Default blue (no metadata)
+        let tooltipText = 'Edit channel - No EPG data'; // Default tooltip
+        
+        // If locked, purple has priority
+        if (channel.epg_update_protected) {
+            metadataClass = 'purple';
+            tooltipText = 'Edit channel - EPG locked (protected from automatic updates)';
+        }
+        // Otherwise evaluate metadata state
+        else if (channel.tvg_id && channel.tvg_name && channel.logo) {
+            metadataClass = 'success';  // Green - complete
+            tooltipText = 'Edit channel - Complete EPG data';
+        } 
+        else if (channel.tvg_id || channel.tvg_name || channel.logo) {
+            metadataClass = 'warning';  // Amber - partial
+            tooltipText = 'Edit channel - Partial EPG data';
+        }
+        
+        // Logo display
+        const logoHtml = channel.logo ? 
+            `<img src="${channel.logo}" alt="Logo" class="channel-logo me-2" style="max-height:20px; max-width:40px;">` : 
+            '';
+            
+        return `
         <tr>
-            <td>${channel.name}</td>
+            <td>
+                <div class="d-flex align-items-center">
+                    ${logoHtml}
+                    ${channel.name}
+                </div>
+            </td>
             <td><code>${channel.id}</code></td>
             <td>
                 ${formatLocalDate(channel.last_processed)}
@@ -441,11 +471,11 @@ function updateChannelList(channels) {
                 <div class="btn-group">
                     <button class="btn btn-sm btn-info" onclick="checkChannelStatus('${channel.id}')" title="Check status">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-shield-check" viewBox="0 0 16 16">
-                            <path d="M5.338 1.59a61.44 61.44 0 0 0-2.837.856.481.481 0 0 0-.328.39c-.554 4.157.726 7.19 2.253 9.188a10.725 10.725 0 0 0 2.287 2.233c.346.244.652.42.893.533.12.057.218.095.293.118a.55.55 0 0 0 .101.025.615.615 0 0 0 .1-.025c.076-.023.174-.061.294-.118.24-.113.547-.29.893-.533a10.726 10.726 0 0 0 2.287-2.233c1.527-1.997 2.807-5.031 2.253-9.188a.48.48 0 0 0-.328-.39c-.651-.213-1.75-.56-2.837-.855C9.552 1.29 8.531 1.067 8 1.067c-.53 0-1.552.223-2.662.524zM5.072.56C6.157.265 7.31 0 8 0s1.843.265 2.928.56c1.11.3 2.229.655 2.887.87a1.54 1.54 0 0 1 1.044 1.262c.596 4.477-.787 7.795-2.465 9.99a11.775 11.775 0 0 1-2.517 2.453 7.159 7.159 0 0 1-1.048.625c-.28.132-.581.24-.829.24s-.548-.108-.829-.24a7.158 7.158 0 0 1-1.048-.625 11.777 11.777 0 0 1-2.517-2.453C1.928 10.487.545 7.169 1.141 2.692A1.54 1.54 0 0 1 2.185 1.43 62.456 62.456 0 0 1 5.072.56z"/>
+                            <path d="M5.338 1.59a61.44 61.44 0 0 0-2.837.856.481.481 0 0 0-.328.39c-.554 4.157.726 7.19 2.253 9.188a10.725 10.725 0 0 0 2.287 2.233c.346.244.652.42.893.533.12.057.218.095.293.118a.55.55 0 0 0 .101.025.615.615 0 0 0 .1-.025c.076-.023.174-.061.294-.118.24-.113.547-.29.893-.533a10.726 10.726 0 0 0 2.287-2.233c1.527-1.997 2.807-5.031 2.253-9.188a.48.48 0 0 0-.328-.39c-.651-.213-1.75-.56-2.837-.855C9.552 1.29 8.531 1.067 8 1.067c-.53 0-1.552.223-2.662.524zM5.072.56C6.157.265 7.31 0 8 0s1.843.265 2.928.56c1.11.3 2.229.655 2.887.87a1.54 1.54 0 0 1 1.044 1.262c.596 4.477-.787 7.795-2.465 9.99a11.775 11.775 0 0 1-2.517 2.453a7.159 7.159 0 0 1-1.048.625c-.28.132-.581.24-.829.24s-.548-.108-.829-.24a7.158 7.158 0 0 1-1.048-.625 11.777 11.777 0 0 1-2.517-2.453C1.928 10.487.545 7.169 1.141 2.692A1.54 1.54 0 0 1 2.185 1.43 62.456 62.456 0 0 1 5.072.56z"/>
                             <path d="M10.854 5.146a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0l-1.5-1.5a.5.5 0 1 1 .708-.708L7.5 7.793l2.646-2.647a.5.5 0 0 1 .708 0z"/>
                         </svg>
                     </button>
-                    <button class="btn btn-sm btn-primary" onclick="editChannel('${channel.id}')" title="Edit channel">
+                    <button class="btn btn-sm btn-${metadataClass}" onclick="editChannel('${channel.id}')" title="${tooltipText}">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
                             <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.646a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
                             <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
@@ -460,7 +490,7 @@ function updateChannelList(channels) {
                 </div>
             </td>
         </tr>
-    `).join('');
+    `}).join('');
     
     // Update displayed channels count in stats
     const displayedChannels = document.getElementById('displayedChannels');

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -443,7 +443,7 @@ function updateChannelList(channels) {
         
         // Logo display
         const logoHtml = channel.logo ? 
-            `<img src="${channel.logo}" alt="Logo" class="channel-logo me-2" style="max-height:20px; max-width:40px;">` : 
+            `<img src="${channel.logo}" alt="Logo" class="channel-logo me-2" style="max-height:60px; max-width:60px;">` : 
             '';
             
         return `

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -13,6 +13,10 @@ async function loadEpgSources() {
         const sourcesContainer = document.getElementById('epgSourcesContainer');
         if (!sourcesContainer) return;
         
+        const hasActiveSources = sources.some(source => source.enabled);
+
+        updateButtonsState(hasActiveSources);
+
         if (sources.length === 0) {
             sourcesContainer.innerHTML = `
                 <div class="alert alert-info">
@@ -61,8 +65,6 @@ async function loadEpgSources() {
             sourcesContainer.appendChild(sourceCard);
         });
         
-        // DO NOT add event listeners here - they are handled via delegation
-        
     } catch (error) {
         console.error('Error loading EPG sources:', error);
         const sourcesContainer = document.getElementById('epgSourcesContainer');
@@ -73,6 +75,7 @@ async function loadEpgSources() {
                 </div>
             `;
         }
+        updateButtonsState(false);
     }
 }
 
@@ -680,6 +683,82 @@ function initializeEpgComponents() {
 // Initialize everything when the DOM is ready
 document.addEventListener('DOMContentLoaded', initializeEpgComponents);
 
+
+
+/**
+ * Update buttons state and show alerts when no active sources
+ * @param {boolean} hasActiveSources - Whether there are any active EPG sources
+ */
+function updateButtonsState(hasActiveSources) {
+    // Buttons to disable
+    const scanChannelsBtn = document.getElementById('scanChannelsBtn');
+    const updateChannelsEpgBtn = document.getElementById('updateChannelsEpgBtn');
+    const addEpgMappingBtn = document.getElementById('addEpgMappingBtn'); // Añadido
+
+    // Alert containers
+    const mappingsTabContent = document.getElementById('mappings');
+    const autoScanTabContent = document.getElementById('automapping');
+    
+    if (!hasActiveSources) {
+        // Disable buttons
+        if (scanChannelsBtn) {
+            scanChannelsBtn.disabled = true;
+            scanChannelsBtn.title = 'Requires active EPG sources';
+        }
+        
+        if (updateChannelsEpgBtn) {
+            updateChannelsEpgBtn.disabled = true;
+            updateChannelsEpgBtn.title = 'Requires active EPG sources';
+        }
+
+        if (addEpgMappingBtn) {
+            addEpgMappingBtn.disabled = true;
+            addEpgMappingBtn.title = 'Requires active EPG sources';
+        }
+        
+        // Add alert if not exists
+        if (mappingsTabContent) {
+            const existingAlert = mappingsTabContent.querySelector('.epg-no-sources-alert');
+            if (!existingAlert) {
+                const alert = document.createElement('div');
+                alert.className = 'alert alert-warning mt-3 epg-no-sources-alert';
+                alert.innerHTML = '<strong>No active EPG sources!</strong> You need to add and enable at least one EPG source to use mapping functions.';
+                mappingsTabContent.insertBefore(alert, mappingsTabContent.firstChild);
+            }
+        }
+        
+        if (autoScanTabContent) {
+            const existingAlert = autoScanTabContent.querySelector('.epg-no-sources-alert');
+            if (!existingAlert) {
+                const alert = document.createElement('div');
+                alert.className = 'alert alert-warning mt-3 epg-no-sources-alert';
+                alert.innerHTML = '<strong>No active EPG sources!</strong> You need to add and enable at least one EPG source to use auto-scan functionality.';
+                autoScanTabContent.insertBefore(alert, autoScanTabContent.firstChild);
+            }
+        }
+    } else {
+        // Enable buttons
+        if (scanChannelsBtn) {
+            scanChannelsBtn.disabled = false;
+            scanChannelsBtn.title = '';
+        }
+        
+        if (updateChannelsEpgBtn) {
+            updateChannelsEpgBtn.disabled = false;
+            updateChannelsEpgBtn.title = '';
+        }
+
+        if (addEpgMappingBtn) {
+            addEpgMappingBtn.disabled = false;
+            addEpgMappingBtn.title = '';
+        }
+        
+        // Remove alerts if exists
+        document.querySelectorAll('.epg-no-sources-alert').forEach(alert => {
+            alert.remove();
+        });
+    }
+}
 // From core.js
 /**
  * Core functionality for the Acestream Scraper application

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -911,18 +911,6 @@ function escapeRegExp(string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-/**
- * Debounce function to limit how often a function runs
- */
-function debounce(func, wait) {
-    let timeout;
-    return function(...args) {
-        const context = this;
-        clearTimeout(timeout);
-        timeout = setTimeout(() => func.apply(context, args), wait);
-    };
-}
-
 // Initialize everything when the DOM is ready
 document.addEventListener('DOMContentLoaded', initializeEpgComponents);
 
@@ -1093,4 +1081,17 @@ function hideLoading() {
     if (loadingElement) {
         loadingElement.style.display = 'none';
     }
+}
+
+// Debounce function to limit API calls
+function debounce(func, wait) {
+    let timeout;
+    return function executedFunction(...args) {
+        const later = () => {
+            clearTimeout(timeout);
+            func(...args);
+        };
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+    };
 }

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -65,7 +65,6 @@ async function loadEpgSources() {
             sourcesContainer.appendChild(sourceCard);
         });
 
-        
     } catch (error) {
         console.error('Error loading EPG sources:', error);
         const sourcesContainer = document.getElementById('epgSourcesContainer');
@@ -140,7 +139,7 @@ async function toggleEpgSource(sourceIdOrElement) {
     isCurrentlyEnabled = btn ? btn.textContent.trim() === 'Disable' : false;
     
     try {
-        // Usar PUT para actualizar el estado
+        // Use PUT to update the status
         await fetch(`/api/epg/sources/${sourceId}`, {
             method: 'PUT',
             headers: {
@@ -151,10 +150,10 @@ async function toggleEpgSource(sourceIdOrElement) {
             })
         });
         
-        // Recargar fuentes para mostrar el estado actualizado
+        // Reload sources to show updated status
         loadEpgSources();
         
-        // Mostrar feedback al usuario
+        // Show feedback to the user
         showAlert('success', `EPG source ${isCurrentlyEnabled ? 'disabled' : 'enabled'} successfully`);
         
     } catch (error) {
@@ -700,7 +699,7 @@ function updateButtonsState(hasActiveSources) {
     // Buttons to disable
     const scanChannelsBtn = document.getElementById('scanChannelsBtn');
     const updateChannelsEpgBtn = document.getElementById('updateChannelsEpgBtn');
-    const addEpgMappingBtn = document.getElementById('addEpgMappingBtn'); // Añadido
+    const addEpgMappingBtn = document.getElementById('addEpgMappingBtn'); // Added
 
     // Alert containers
     const mappingsTabContent = document.getElementById('mappings');

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -21,7 +21,7 @@ async function loadEpgSources() {
             sourcesContainer.innerHTML = `
                 <div class="alert alert-info">
                     No EPG source configured. Add one to enable EPG functionality.
-                </div
+                </div>
             `;
             return;
         }

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -52,7 +52,7 @@ async function loadEpgSources() {
                             <small class="text-muted d-block">Last updated: ${lastUpdated}</small>
                         </div>
                         <div class="d-flex flex-nowrap">
-                            <button type="button" class="btn btn-sm btn-secondary me-2 toggle-source" data-id="${source.id}" title="${source.enabled ? 'Disable' : 'Enable'}">
+                            <button type="button" class="btn btn-sm ${source.enabled ? 'btn-warning' : 'btn-success'} me-2 toggle-source" data-id="${source.id}" title="${source.enabled ? 'Disable' : 'Enable'}">
                                 ${source.enabled ? 'Disable' : 'Enable'}
                             </button>
                             <button type="button" class="btn btn-sm btn-danger delete-source" data-id="${source.id}" title="Delete">

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -1,0 +1,745 @@
+/**
+ * EPG (Electronic Program Guide) management functionality
+ */
+
+/**
+ * Load EPG sources and display them as cards
+ */
+async function loadEpgSources() {
+    try {
+        const response = await fetch('/api/epg/sources');
+        const sources = await response.json();
+        
+        const sourcesContainer = document.getElementById('epgSourcesContainer');
+        if (!sourcesContainer) return;
+        
+        if (sources.length === 0) {
+            sourcesContainer.innerHTML = `
+                <div class="alert alert-info">
+                    No EPG source configured. Add one to enable EPG functionality.
+                </div
+            `;
+            return;
+        }
+        
+        sourcesContainer.innerHTML = '';
+        
+        // Display sources in a balanced format
+        sources.forEach(source => {
+            const lastUpdated = source.last_updated ? new Date(source.last_updated).toLocaleString() : 'Never';
+            const statusClass = source.enabled ? 
+                (source.error_count > 0 ? 'warning' : 'success') : 
+                'secondary';
+            const statusText = source.enabled ? 
+                (source.error_count > 0 ? 'No EPG data' : 'Active') : 
+                'Disabled';
+            
+            // Create balanced layout
+            const sourceCard = document.createElement('div');
+            sourceCard.className = 'card mb-3';
+            sourceCard.innerHTML = `
+                <div class="card-body py-2 px-3">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div class="me-2" style="min-width: 0; flex: 1">
+                            <div class="d-flex align-items-center mb-1">
+                                <span class="badge bg-${statusClass} me-2">${statusText}</span>
+                                <span class="text-truncate" style="max-width: 100%;" title="${source.url}">${source.url}</span>
+                            </div>
+                            <small class="text-muted d-block">Last updated: ${lastUpdated}</small>
+                        </div>
+                        <div class="d-flex flex-nowrap">
+                            <button type="button" class="btn btn-sm btn-secondary me-2 toggle-source" data-id="${source.id}" title="${source.enabled ? 'Disable' : 'Enable'}">
+                                ${source.enabled ? 'Disable' : 'Enable'}
+                            </button>
+                            <button type="button" class="btn btn-sm btn-danger delete-source" data-id="${source.id}" title="Delete">
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            `;
+            sourcesContainer.appendChild(sourceCard);
+        });
+        
+        // DO NOT add event listeners here - they are handled via delegation
+        
+    } catch (error) {
+        console.error('Error loading EPG sources:', error);
+        const sourcesContainer = document.getElementById('epgSourcesContainer');
+        if (sourcesContainer) {
+            sourcesContainer.innerHTML = `
+                <div class="alert alert-danger">
+                    Error loading EPG sources
+                </div>
+            `;
+        }
+    }
+}
+
+/**
+ * Load EPG string mappings and display in table format
+ */
+async function loadEpgMappings() {
+    try {
+        const response = await fetch('/api/epg/mappings');
+        const mappings = await response.json();
+        
+        const mappingsTable = document.getElementById('epgMappingsTable');
+        if (!mappingsTable) return;
+        
+        if (mappings.length === 0) {
+            mappingsTable.innerHTML = '<tr><td colspan="3" class="text-center">No pattern mappings configured</td></tr>';
+            return;
+        }
+        
+        mappingsTable.innerHTML = '';
+        mappings.forEach(mapping => {
+            const isExclusion = mapping.search_pattern.startsWith('!');
+            const displayPattern = isExclusion ? 
+                mapping.search_pattern.substring(1) : 
+                mapping.search_pattern;
+                
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>
+                    ${isExclusion ? 
+                        `<span class="badge bg-danger">EXCLUDE</span> ${displayPattern}` : 
+                        displayPattern}
+                </td>
+                <td>${isExclusion ? '---' : mapping.epg_channel_id}</td>
+                <td>
+                    <button type="button" class="btn btn-sm btn-danger delete-mapping" data-id="${mapping.id}" title="Delete">
+                        Delete
+                    </button>
+                </td>
+            `;
+            mappingsTable.appendChild(row);
+        });
+    } catch (error) {
+        console.error('Error loading EPG mappings:', error);
+        const mappingsTable = document.getElementById('epgMappingsTable');
+        if (mappingsTable) {
+            mappingsTable.innerHTML = '<tr><td colspan="3" class="text-center text-danger">Error loading pattern mappings</td></tr>';
+        }
+    }
+}
+
+/**
+ * Toggle an EPG source's enabled status
+ * @param {string|Event} sourceId - Either the source ID or the click event
+ */
+async function toggleEpgSource(sourceIdOrElement) {
+    let sourceId, isCurrentlyEnabled;
+    
+    sourceId = sourceIdOrElement;
+    const btn = document.querySelector(`.toggle-source[data-id="${sourceId}"]`);
+    isCurrentlyEnabled = btn ? btn.textContent.trim() === 'Disable' : false;
+    
+    try {
+        // Usar PUT para actualizar el estado
+        await fetch(`/api/epg/sources/${sourceId}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                enabled: !isCurrentlyEnabled
+            })
+        });
+        
+        // Recargar fuentes para mostrar el estado actualizado
+        loadEpgSources();
+        
+        // Mostrar feedback al usuario
+        showAlert('success', `EPG source ${isCurrentlyEnabled ? 'disabled' : 'enabled'} successfully`);
+        
+    } catch (error) {
+        console.error('Error toggling EPG source:', error);
+        showAlert('danger', 'Failed to toggle EPG source status');
+    }
+}
+
+/**
+ * Delete an EPG source from the system
+ * @param {string} sourceId - The ID of the source to delete
+ */
+async function deleteEpgSource(sourceId) {
+    const confirmed = window.confirm("Are you sure you want to delete this EPG source?");
+    if (!confirmed) return;
+    
+    try {
+        const response = await fetch(`/api/epg/sources/${sourceId}`, {
+            method: 'DELETE'
+        });
+        
+        if (!response.ok) {
+            throw new Error('Failed to delete EPG source');
+        }
+        
+        console.log('EPG source deleted successfully');
+        
+        // Reload sources list
+        loadEpgSources();
+    } catch (error) {
+        console.error('Error deleting EPG source:', error);
+    }
+}
+
+/**
+ * Add a new EPG source with validation and duplicate checking
+ */
+async function addEpgSource() {
+    const urlInput = document.getElementById('epgSourceUrl');
+    const url = urlInput.value.trim();
+    
+    // Basic URL validation
+    if (!url) {
+        showInputError(urlInput, 'URL is required');
+        return;
+    }
+    
+    // Validate it's a proper URL
+    try {
+        const urlObj = new URL(url);
+        if (urlObj.protocol !== 'http:' && urlObj.protocol !== 'https:') {
+            showInputError(urlInput, 'URL must start with http:// or https://');
+            return;
+        }
+    } catch (e) {
+        showInputError(urlInput, 'Please enter a valid URL');
+        return;
+    }
+    
+    try {
+        // Check if this URL already exists
+        const existingSourcesResponse = await fetch('/api/epg/sources');
+        const existingSources = await existingSourcesResponse.json();
+        
+        const isDuplicate = existingSources.some(source => 
+            source.url.toLowerCase() === url.toLowerCase()
+        );
+        
+        if (isDuplicate) {
+            showInputError(urlInput, 'This EPG source URL already exists');
+            return;
+        }
+        
+        // If not a duplicate, proceed with adding
+        const response = await fetch('/api/epg/sources', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                url: url,
+                enabled: true
+            })
+        });
+        
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to add EPG source');
+        }
+        
+        // Close modal and reset form
+        const modal = bootstrap.Modal.getInstance(document.getElementById('addEpgSourceModal'));
+        modal.hide();
+        urlInput.value = '';
+        clearInputError(urlInput);
+        
+        // Reload sources list
+        loadEpgSources();
+        
+        console.log('EPG source added successfully');
+    } catch (error) {
+        console.error('Error adding EPG source:', error);
+        showInputError(urlInput, error.message || 'Error adding EPG source');
+    }
+}
+
+/**
+ * Helper functions for handling input validation errors
+ */
+function showInputError(inputElement, message) {
+    // Remove previous error message if exists
+    clearInputError(inputElement);
+    
+    // Add error class
+    inputElement.classList.add('is-invalid');
+    
+    // Create and add error message
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'invalid-feedback';
+    errorDiv.textContent = message;
+    
+    inputElement.parentNode.appendChild(errorDiv);
+}
+
+function clearInputError(inputElement) {
+    inputElement.classList.remove('is-invalid');
+    
+    // Remove previous error messages
+    const existingError = inputElement.parentNode.querySelector('.invalid-feedback');
+    if (existingError) {
+        existingError.remove();
+    }
+}
+
+/**
+ * Add a new EPG mapping with validation
+ */
+async function addEpgMapping() {
+    try {
+        const pattern = document.getElementById('epgSearchPattern').value;
+        const isExclusion = document.getElementById('epgIsExclusion').checked;
+        const channelId = isExclusion ? '' : document.getElementById('epgChannelId').value;
+        
+        // Validate data
+        if (!pattern || (pattern.trim() === '')) {
+            showAlert('danger', 'Search pattern is required');
+            return;
+        }
+        
+        if (!isExclusion && (!channelId || channelId.trim() === '')) {
+            showAlert('danger', 'EPG channel ID is required for non-exclusion rules');
+            return;
+        }
+        
+        // Format data
+        const formattedPattern = isExclusion ? '!' + pattern : pattern;
+        
+        const response = await fetch('/api/epg/mappings', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                search_pattern: formattedPattern,
+                epg_channel_id: channelId
+            })
+        });
+        
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to add EPG mapping');
+        }
+        
+        // Close modal and refresh data
+        const modal = bootstrap.Modal.getInstance(document.getElementById('addEpgMappingModal'));
+        if (modal) {
+            modal.hide();
+        }
+        
+        // Refresh data
+        loadEpgMappings();
+        showAlert('success', 'EPG mapping added successfully');
+    } catch (error) {
+        console.error('Error adding EPG mapping:', error);
+        showAlert('danger', 'Error adding EPG mapping: ' + error.message);
+    }
+}
+
+/**
+ * Delete an EPG mapping
+ * @param {string} mappingId - The ID of the mapping to delete
+ */
+async function deleteEpgMapping(mappingId) {
+    if (!confirm('Are you sure you want to delete this pattern mapping?')) {
+        return;
+    }
+    
+    try {
+        await fetch(`/api/epg/mappings/${mappingId}`, {
+            method: 'DELETE'
+        });
+        
+        // Reload mappings list
+        loadEpgMappings();
+        
+        console.log('Pattern mapping deleted successfully');
+    } catch (error) {
+        console.error('Error deleting pattern mapping:', error);
+    }
+}
+
+/**
+ * Refresh EPG data from all configured sources
+ */
+async function refreshEpgData() {
+    try {
+        const btn = document.getElementById('refreshEpgDataBtn');
+        if (btn) {
+            btn.disabled = true;
+            btn.textContent = 'Refreshing...';
+        }
+        
+        const response = await fetch('/api/epg/refresh', {
+            method: 'POST'
+        });
+        
+        if (!response.ok) {
+            throw new Error('Failed to refresh EPG data');
+        }
+        
+        const result = await response.json();
+        
+        console.log(`EPG data refreshed: ${result.channels_found} channels found`);
+        
+        // Reload sources list to update last_updated info
+        loadEpgSources();
+    } catch (error) {
+        console.error('Error refreshing EPG data:', error);
+    } finally {
+        const btn = document.getElementById('refreshEpgDataBtn');
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = 'Refresh EPG Channels';
+        }
+    }
+}
+
+/**
+ * Update channel EPG data using the configured mapping rules
+ * Includes options for respecting existing data and cleaning unmatched channels
+ */
+async function updateChannelsEpg() {
+    try {
+        showLoading();
+        
+        // Disable the button and change text to show progress
+        const btn = document.getElementById('updateChannelsEpgBtn');
+        if (btn) {
+            btn.disabled = true;
+            btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Updating...';
+        }
+
+        // Read state from both checkboxes
+        const respectExisting = document.getElementById('updateRespectExisting')?.checked || false;
+        const cleanUnmatched = document.getElementById('updateCleanUnmatched')?.checked || false;
+        
+        console.log('Update channels options:', {
+            respect_existing: respectExisting,
+            clean_unmatched: cleanUnmatched
+        });
+        
+        const response = await fetch('/api/epg/update-channels', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                respect_existing: respectExisting,
+                clean_unmatched: cleanUnmatched
+            })
+        });
+        
+        if (!response.ok) {
+            const error = await response.json();
+            throw new Error(error.message || 'Failed to update channels with EPG data');
+        }
+        
+        const result = await response.json();
+        
+        // Use the new stats format
+        const stats = result.stats;
+        
+        // Display message with the new format
+        showAlert('success', `EPG update completed. 
+            Updated: ${stats.updated || 0}, 
+            Cleaned: ${stats.cleaned || 0}, 
+            Locked: ${stats.locked || 0}, 
+            Excluded: ${stats.excluded || 0}`);
+        
+        // Update UI if needed
+        if (typeof refreshData === 'function') {
+            await refreshData();
+        }
+        
+        return result;
+    } catch (error) {
+        console.error('Error updating channels with EPG data:', error);
+        showAlert('danger', 'Error updating channels with EPG data: ' + error.message);
+        throw error;
+    } finally {
+        hideLoading();
+
+        // Restore button state
+        const btn = document.getElementById('updateChannelsEpgBtn');
+        if (btn) {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-arrow-repeat"></i> Update EPG Mappings';
+        }
+    }
+}
+
+/**
+ * Load EPG channel options for datalist
+ * Caches results to avoid unnecessary API calls
+ */
+async function loadEpgChannelOptions() {
+    try {
+        // If we haven't cached the data yet, fetch it
+        if (!window.epgChannelsList || window.epgChannelsList.length === 0) {
+            // Get the available channel IDs
+            const channelResponse = await fetch('/api/epg/channels');
+            if (!channelResponse.ok) {
+                throw new Error('Failed to fetch EPG channel IDs');
+            }
+            
+            const channelData = await channelResponse.json();
+            window.epgChannelsList = channelData;
+        }
+        
+        // Populate the datalist with options
+        const datalist = document.getElementById('epgChannelOptions');
+        if (datalist) {
+            datalist.innerHTML = '';
+            window.epgChannelsList.forEach(channel => {
+                const option = document.createElement('option');
+                option.value = channel.id;
+                option.text = channel.name || channel.id;
+                datalist.appendChild(option);
+            });
+        }
+    } catch (error) {
+        console.error('Error loading EPG channel options:', error);
+    }
+}
+
+/**
+ * Automatically scan and match channels with EPG data based on similarity
+ * Configurable with threshold and options for handling existing data
+ */
+async function autoScanChannels() {
+    try {
+        showLoading();
+        
+        // Get slider value, converted to decimal (0.5-0.95)
+        const thresholdSlider = document.getElementById('similarityThreshold');
+        const threshold = thresholdSlider ? (parseInt(thresholdSlider.value) / 100) : 0.8;
+        
+        // Read checkbox states
+        const cleanUnmatched = document.getElementById('cleanUnmatched')?.checked || false;
+        const respectExisting = document.getElementById('respectExisting')?.checked || false;
+        
+        console.log('Auto-scan options:', {
+            threshold: threshold,
+            cleanUnmatched: cleanUnmatched,
+            respectExisting: respectExisting
+        });
+        
+        const response = await fetch('/api/epg/auto-scan', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                threshold: threshold,
+                clean_unmatched: cleanUnmatched,
+                respect_existing: respectExisting
+            })
+        });
+        
+        if (!response.ok) {
+            const data = await response.json();
+            throw new Error(data.error || 'Failed to perform auto-scan');
+        }
+        
+        const result = await response.json();
+        
+        // Display results
+        showAlert('success', `Auto-scan completed successfully. 
+            Processed: ${result.total} channels, 
+            Matched: ${result.matched}, 
+            Cleaned: ${result.cleaned || 0},
+            Skipped: ${result.skipped || 0} (already had EPG data)`
+        );
+        
+        // Update channel list if the function exists
+        if (typeof refreshData === 'function') {
+            await refreshData();
+        }
+    } catch (error) {
+        console.error('Error during auto-scan:', error);
+        showAlert('danger', 'Error during auto-scan: ' + error.message);
+    } finally {
+        hideLoading();
+        
+        // Restore button state
+        const btn = document.getElementById('scanChannelsBtn');
+        if (btn) {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-search"></i> Scan Channels';
+        }
+    }
+}
+
+/**
+ * Initialize all EPG components and event handlers
+ */
+function initializeEpgComponents() {
+    // 1. Load initial data
+    loadEpgSources();
+    loadEpgMappings();
+    
+    // 2. Configure threshold slider
+    const thresholdSlider = document.getElementById('similarityThreshold');
+    const thresholdValue = document.getElementById('thresholdValue');
+    if (thresholdSlider && thresholdValue) {
+        // Initial configuration
+        thresholdValue.textContent = `${thresholdSlider.value}%`;
+        
+        // Change listener
+        thresholdSlider.addEventListener('input', function() {
+            thresholdValue.textContent = `${this.value}%`;
+        });
+    }
+    
+    // 3. Configure exclusion checkbox
+    const exclusionCheckbox = document.getElementById('epgIsExclusion');
+    const channelIdContainer = document.getElementById('epgChannelIdContainer');
+    if (exclusionCheckbox && channelIdContainer) {
+        exclusionCheckbox.addEventListener('change', function() {
+            const channelIdField = document.getElementById('epgChannelId');
+            if (this.checked) {
+                channelIdContainer.style.display = 'none';
+                if (channelIdField) channelIdField.removeAttribute('required');
+            } else {
+                channelIdContainer.style.display = 'block';
+                if (channelIdField) channelIdField.setAttribute('required', 'required');
+            }
+        });
+    }
+    
+    // 4. Configure global event delegation (once)
+    document.addEventListener('click', function(event) {
+        // EPG source events
+        if (event.target.closest('.toggle-source')) {
+            const btn = event.target.closest('.toggle-source');
+            toggleEpgSource(btn.dataset.id);
+            event.preventDefault();
+        }
+        else if (event.target.closest('.delete-source')) {
+            const btn = event.target.closest('.delete-source');
+            deleteEpgSource(btn.dataset.id);
+            event.preventDefault();
+        }
+        
+        // EPG mapping events
+        else if (event.target.closest('.delete-mapping')) {
+            const btn = event.target.closest('.delete-mapping');
+            deleteEpgMapping(btn.dataset.id);
+            event.preventDefault();
+        }
+        
+        // Action buttons
+        else if (event.target.id === 'addEpgSourceBtn') {
+            const modal = new bootstrap.Modal(document.getElementById('addEpgSourceModal'));
+            modal.show();
+        }
+        else if (event.target.id === 'saveEpgSourceBtn') {
+            addEpgSource();
+        }
+        else if (event.target.id === 'addEpgMappingBtn') {
+            // Reset form when opening
+            const mappingForm = document.getElementById('epgMappingForm');
+            if (mappingForm) mappingForm.reset();
+            
+            // Show channel ID container by default
+            const channelIdContainer = document.getElementById('epgChannelIdContainer');
+            if (channelIdContainer) channelIdContainer.style.display = 'block';
+            
+            // Reset required attribute
+            const channelIdField = document.getElementById('epgChannelId');
+            if (channelIdField) channelIdField.setAttribute('required', 'required');
+            
+            const modal = new bootstrap.Modal(document.getElementById('addEpgMappingModal'));
+            modal.show();
+            
+            // Load channel options
+            loadEpgChannelOptions();
+        }
+        else if (event.target.id === 'saveEpgMappingBtn') {
+            addEpgMapping();
+        }
+        else if (event.target.id === 'refreshEpgDataBtn') {
+            refreshEpgData(event.target);
+        }
+        else if (event.target.id === 'updateChannelsEpgBtn') {
+            updateChannelsEpg();
+        }
+        else if (event.target.id === 'scanChannelsBtn') {
+            const btn = event.target;
+            btn.disabled = true;
+            btn.innerHTML = '<i class="bi bi-hourglass-split"></i> Scanning...';
+            autoScanChannels();
+        }
+    });
+}
+
+// Initialize everything when the DOM is ready
+document.addEventListener('DOMContentLoaded', initializeEpgComponents);
+
+// From core.js
+/**
+ * Core functionality for the Acestream Scraper application
+ */
+
+// Show alert message to the user
+function showAlert(type, message, duration = 5000) {
+    // Create alert container if it doesn't exist
+    let alertContainer = document.getElementById('alertContainer');
+    if (!alertContainer) {
+        alertContainer = document.createElement('div');
+        alertContainer.id = 'alertContainer';
+        alertContainer.className = 'toast-container position-fixed top-0 end-0 p-3';
+        document.body.appendChild(alertContainer);
+    }
+    
+    // Generate a unique ID for this alert
+    const alertId = 'alert-' + Date.now();
+    
+    // Create the alert element
+    const alertHTML = `
+        <div id="${alertId}" class="toast align-items-center text-white bg-${type === 'error' ? 'danger' : type === 'success' ? 'success' : 'primary'}" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="d-flex">
+                <div class="toast-body">
+                    ${message}
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+        </div>
+    `;
+    
+    // Add the alert to the container
+    alertContainer.insertAdjacentHTML('beforeend', alertHTML);
+    
+    // Initialize and show the toast
+    const toastElement = document.getElementById(alertId);
+    const toast = new bootstrap.Toast(toastElement, {
+        autohide: true,
+        delay: duration
+    });
+    toast.show();
+    
+    // Remove the toast from DOM after it's hidden
+    toastElement.addEventListener('hidden.bs.toast', () => {
+        toastElement.remove();
+    });
+}
+
+// Show loading spinner
+function showLoading() {
+    const loadingElement = document.getElementById('loading');
+    if (loadingElement) {
+        loadingElement.style.display = 'inline-block';
+    }
+}
+
+// Hide loading spinner
+function hideLoading() {
+    const loadingElement = document.getElementById('loading');
+    if (loadingElement) {
+        loadingElement.style.display = 'none';
+    }
+}

--- a/app/static/js/epg.js
+++ b/app/static/js/epg.js
@@ -64,6 +64,7 @@ async function loadEpgSources() {
             `;
             sourcesContainer.appendChild(sourceCard);
         });
+
         
     } catch (error) {
         console.error('Error loading EPG sources:', error);
@@ -322,9 +323,15 @@ async function addEpgMapping() {
             })
         });
         
+        // Prevent duplicates
+        if (response.status === 409) {
+            showAlert('warning', 'This pattern already exists');
+            return;
+        }
+        
         if (!response.ok) {
-            const error = await response.json();
-            throw new Error(error.message || 'Failed to add EPG mapping');
+            const errorData = await response.json();
+            throw new Error(errorData.message || 'Failed to add EPG mapping');
         }
         
         // Close modal and refresh data

--- a/app/templates/config.html
+++ b/app/templates/config.html
@@ -335,10 +335,14 @@
         </div>
     </div>
 </div>
+
+<!-- Include the EPG section -->
+{% include 'partials/config/epg_section.html' %}
 {% endblock %}
 
 {% block scripts %}
 <script src="{{ url_for('static', filename='js/config.js') }}"></script>
 <script src="{{ url_for('static', filename='js/urls.js') }}"></script>
 <script src="{{ url_for('static', filename='js/warp.js') }}"></script>
+<script src="{{ url_for('static', filename='js/epg.js') }}"></script>
 {% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -73,7 +73,28 @@
                 margin-left: auto;
             }
         }
-        {% block additional_styles %}{% endblock %}
+        /* Custom purple color class for locked EPG items */
+        .bg-purple {
+            background-color: #6f42c1 !important;
+            color: white !important;
+        }
+
+        .btn-purple {
+            background-color: #6f42c1 !important;
+            border-color: #6f42c1 !important;
+            color: white !important;
+        }
+
+        .border-purple {
+            border-color: #6f42c1 !important;
+        }
+
+        /* Channel logo sizing */
+        .channel-logo {
+            object-fit: contain;
+            border-radius: 3px;
+        }
+      
     </style>
     {% block head_extra %}{% endblock %}
 </head>

--- a/app/templates/partials/channel_list.html
+++ b/app/templates/partials/channel_list.html
@@ -67,6 +67,13 @@
                         <label for="editChannelM3uSource" class="form-label">M3U Source</label>
                         <input type="text" class="form-control" id="editChannelM3uSource">
                     </div>
+
+                    <div class="col-md-6">
+                        <input class="form-check-input" type="checkbox" id="editChannelEpgLocked">
+                        <label class="form-check-label" for="editChannelEpgLocked">
+                            Lock mapping from EPG source
+                        </label>
+                    </div>
                 </form>
             </div>
             <div class="modal-footer">

--- a/app/templates/partials/config/epg_section.html
+++ b/app/templates/partials/config/epg_section.html
@@ -1,0 +1,203 @@
+<!-- EPG Management Configuration Card -->
+<div class="card mb-4">
+    <div class="card-header">
+        <h5 class="card-title mb-0">EPG Configuration</h5>
+    </div>
+    
+    <div class="card-body">
+        <!-- Navigation tabs for EPG management sections -->
+        <ul class="nav nav-tabs mb-3" id="epgTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="sources-tab" data-bs-toggle="tab" data-bs-target="#sources" type="button" role="tab" aria-controls="sources" aria-selected="true">EPG Sources</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="mappings-tab" data-bs-toggle="tab" data-bs-target="#mappings" type="button" role="tab" aria-controls="mappings" aria-selected="false">Channel Mappings</button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="automapping-tab" data-bs-toggle="tab" data-bs-target="#automapping" type="button" role="tab" aria-controls="automapping" aria-selected="false">Auto Scan</button>
+            </li>
+        </ul>
+        
+        <!-- Tab content panels -->
+        <div class="tab-content" id="epgTabsContent">
+            <!-- EPG Sources Tab: Manage XMLTV data sources -->
+            <div class="tab-pane fade show active" id="sources" role="tabpanel" aria-labelledby="sources-tab">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5>EPG Sources</h5>
+                    <div>
+                        <button id="addEpgSourceBtn" class="btn btn-primary btn-sm">
+                            <i class="bi bi-plus-lg"></i> Add Source
+                        </button>
+                    </div>
+                </div>
+                
+                <div id="epgSourcesContainer">
+                    <!-- Dynamic content: EPG sources will be loaded here by JavaScript -->
+                </div>
+                <div class="text-end mt-3">
+                    <button id="refreshEpgDataBtn" class="btn btn-primary">
+                        <i class="bi bi-arrow-clockwise"></i> Refresh EPG Channels
+                    </button>
+                </div>
+            </div>
+            
+            <!-- Channel Mappings Tab: Configure EPG data mapping rules -->
+            <div class="tab-pane fade" id="mappings" role="tabpanel" aria-labelledby="mappings-tab">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h5>Channel Mappings</h5>
+                    <div>
+                        <button id="addEpgMappingBtn" class="btn btn-primary btn-sm">
+                            <i class="bi bi-plus-lg"></i> Add Mapping
+                        </button>
+                    </div>
+                </div>
+                
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h6>Mapping Options</h6>
+                        <div class="form-check mb-2">
+                            <input class="form-check-input" type="checkbox" id="updateCleanUnmatched">
+                            <label class="form-check-label" for="updateCleanUnmatched">
+                                Clean EPG data if no match found
+                            </label>
+                        </div>
+                        
+                        <div class="form-check mb-3">
+                            <input class="form-check-input" type="checkbox" id="updateRespectExisting">
+                            <label class="form-check-label" for="updateRespectExisting">
+                                Don't modify channels that already have EPG data
+                            </label>
+                        </div>
+                        
+                        <div class="text-end">
+                            <button id="updateChannelsEpgBtn" class="btn btn-primary">
+                                <i class="bi bi-arrow-repeat"></i> Update EPG Mappings
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>Search Pattern</th>
+                                <th>EPG Channel ID</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody id="epgMappingsTable">
+                            <!-- Dynamic content: EPG mapping rules will be loaded here by JavaScript -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            
+            <!-- Auto Scan Tab: Automatically match channels with EPG data -->
+            <div class="tab-pane fade" id="automapping" role="tabpanel" aria-labelledby="automapping-tab">
+                <div class="row mb-3">
+                    <div class="col-md-8">
+                        <h5>Auto-Scan Channels</h5>
+                        <p class="text-muted">Automatically match channels with EPG data based on name similarity</p>
+                    </div>
+                </div>
+                
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h6>Similarity Threshold</h6>
+                        <div class="mb-3">
+                            <label for="similarityThreshold" class="form-label">
+                                <span id="thresholdValue">75%</span> - Minimum match confidence
+                            </label>
+                            <input type="range" class="form-range" min="50" max="95" step="5" value="75" id="similarityThreshold">
+                        </div>
+                        
+                        <div class="form-check mb-2">
+                            <input class="form-check-input" type="checkbox" id="cleanUnmatched">
+                            <label class="form-check-label" for="cleanUnmatched">
+                                Clean EPG data if no match found
+                            </label>
+                        </div>
+                        
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="respectExisting">
+                            <label class="form-check-label" for="respectExisting">
+                                Don't modify channels that already have EPG data
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="text-end">
+                    <button class="btn btn-primary" id="scanChannelsBtn">
+                        <i class="bi bi-search"></i> Scan Channels
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal: Add New EPG Source -->
+<div class="modal fade" id="addEpgSourceModal" tabindex="-1" aria-labelledby="addEpgSourceModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addEpgSourceModalLabel">Add EPG Source</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addEpgSourceForm">
+                    <div class="mb-3">
+                        <label for="epgSourceUrl" class="form-label">XMLTV URL</label>
+                        <input type="url" class="form-control" id="epgSourceUrl" required placeholder="Enter XMLTV URL (http/https)">
+                        <div class="form-text">URL to an XMLTV format EPG data source</div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="saveEpgSourceBtn">Add Source</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal: Add Channel Mapping Rule -->
+<div class="modal fade" id="addEpgMappingModal" tabindex="-1" aria-labelledby="addEpgMappingModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addEpgMappingModalLabel">Add Channel Mapping</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="epgMappingForm">
+                    <div class="mb-3">
+                        <label for="epgSearchPattern" class="form-label">Search Pattern</label>
+                        <input type="text" class="form-control" id="epgSearchPattern" required placeholder="Enter text to search in channel names">
+                        <div class="form-text">Text pattern to match in Acestream channel names (case insensitive)</div>
+                    </div>
+                    
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" class="form-check-input" id="epgIsExclusion">
+                        <label class="form-check-label" for="epgIsExclusion">Exclusion rule</label>
+                        <div class="form-text">If checked, channels matching this pattern will be excluded from EPG mapping</div>
+                    </div>
+                    
+                    <div class="mb-3" id="epgChannelIdContainer">
+                        <label for="epgChannelId" class="form-label">EPG Channel ID</label>
+                        <input type="text" class="form-control" id="epgChannelId" required placeholder="Enter EPG channel ID" list="epgChannelOptions">
+                        <datalist id="epgChannelOptions">
+                            <!-- Dynamic content: EPG channel options will be populated by JavaScript -->
+                        </datalist>
+                        <div class="form-text">ID of the EPG channel to map to (tvg-id attribute)</div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="saveEpgMappingBtn">Add Mapping</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/templates/partials/config/epg_section.html
+++ b/app/templates/partials/config/epg_section.html
@@ -54,7 +54,6 @@
                 
                 <div class="card mb-3">
                     <div class="card-body">
-                        <h6>Mapping Options</h6>
                         <div class="form-check mb-2">
                             <input class="form-check-input" type="checkbox" id="updateCleanUnmatched">
                             <label class="form-check-label" for="updateCleanUnmatched">
@@ -67,12 +66,6 @@
                             <label class="form-check-label" for="updateRespectExisting">
                                 Don't modify channels that already have EPG data
                             </label>
-                        </div>
-                        
-                        <div class="text-end">
-                            <button id="updateChannelsEpgBtn" class="btn btn-primary">
-                                <i class="bi bi-arrow-repeat"></i> Update EPG Mappings
-                            </button>
                         </div>
                     </div>
                 </div>
@@ -90,6 +83,11 @@
                             <!-- Dynamic content: EPG mapping rules will be loaded here by JavaScript -->
                         </tbody>
                     </table>
+                </div>
+                <div class="text-end">
+                    <button id="updateChannelsEpgBtn" class="btn btn-primary">
+                        <i class="bi bi-arrow-repeat"></i> Update EPG Mappings
+                    </button>
                 </div>
             </div>
             

--- a/app/templates/partials/config/epg_section.html
+++ b/app/templates/partials/config/epg_section.html
@@ -175,6 +175,25 @@
                         <input type="text" class="form-control" id="epgSearchPattern" required placeholder="Enter text to search in channel names">
                         <div class="form-text">Text pattern to match in Acestream channel names (case insensitive)</div>
                     </div>
+
+                    <!-- Channel matching preview panel -->
+                    <div class="mb-3">
+                        <div class="card">
+                            <div class="card-header py-1">
+                                <div class="d-flex justify-content-between align-items-center">
+                                        Matching Channels Preview
+                                    <span class="badge bg-secondary" id="matchCount">0</span>
+                                </div>
+                            </div>
+                            <div class="card-body p-0">
+                                <div id="matchingChannelsPreview" style="max-height: 200px; overflow-y: auto;">
+                                    <div class="p-3 text-center text-muted">
+                                        <small>Start typing to see matching channels</small>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     
                     <div class="mb-3 form-check">
                         <input type="checkbox" class="form-check-input" id="epgIsExclusion">

--- a/app/templates/partials/config/epg_section.html
+++ b/app/templates/partials/config/epg_section.html
@@ -11,10 +11,10 @@
                 <button class="nav-link active" id="sources-tab" data-bs-toggle="tab" data-bs-target="#sources" type="button" role="tab" aria-controls="sources" aria-selected="true">EPG Sources</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="mappings-tab" data-bs-toggle="tab" data-bs-target="#mappings" type="button" role="tab" aria-controls="mappings" aria-selected="false">Channel Mappings</button>
+                <button class="nav-link" id="automapping-tab" data-bs-toggle="tab" data-bs-target="#automapping" type="button" role="tab" aria-controls="automapping" aria-selected="false">Auto Map</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="automapping-tab" data-bs-toggle="tab" data-bs-target="#automapping" type="button" role="tab" aria-controls="automapping" aria-selected="false">Auto Scan</button>
+                <button class="nav-link" id="mappings-tab" data-bs-toggle="tab" data-bs-target="#mappings" type="button" role="tab" aria-controls="mappings" aria-selected="false">Channel Mappings</button>
             </li>
         </ul>
         
@@ -91,11 +91,11 @@
                 </div>
             </div>
             
-            <!-- Auto Scan Tab: Automatically match channels with EPG data -->
+            <!-- Auto Map Tab: Automatically match channels with EPG data -->
             <div class="tab-pane fade" id="automapping" role="tabpanel" aria-labelledby="automapping-tab">
                 <div class="row mb-3">
                     <div class="col-md-8">
-                        <h5>Auto-Scan Channels</h5>
+                        <h5>Auto Map Channels</h5>
                         <p class="text-muted">Automatically match channels with EPG data based on name similarity</p>
                     </div>
                 </div>
@@ -127,7 +127,7 @@
                 </div>
                 <div class="text-end">
                     <button class="btn btn-primary" id="scanChannelsBtn">
-                        <i class="bi bi-search"></i> Scan Channels
+                        <i class="bi bi-search"></i> Auto Map Channels
                     </button>
                 </div>
             </div>

--- a/app/templates/partials/config/epg_section.html
+++ b/app/templates/partials/config/epg_section.html
@@ -63,7 +63,7 @@
                         </div>
                         
                         <div class="form-check mb-3">
-                            <input class="form-check-input" type="checkbox" id="updateRespectExisting">
+                            <input class="form-check-input" type="checkbox" id="updateRespectExisting" checked>
                             <label class="form-check-label" for="updateRespectExisting">
                                 Don't modify channels that already have EPG data
                             </label>
@@ -120,7 +120,7 @@
                         </div>
                         
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="respectExisting">
+                            <input class="form-check-input" type="checkbox" id="respectExisting" checked>
                             <label class="form-check-label" for="respectExisting">
                                 Don't modify channels that already have EPG data
                             </label>

--- a/migrations/versions/20250406_add_epg_tables_and_epg_update_protected_field.py
+++ b/migrations/versions/20250406_add_epg_tables_and_epg_update_protected_field.py
@@ -1,0 +1,73 @@
+"""20250406_add_epg_update_protected
+
+Revision ID: 20250406_add_epg_update_protected
+Revises: 20250330_add_added_at
+Create Date: 2025-04-06 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '20250406_add_epg_tables_and_epg_update_protected_field'
+down_revision = '20250330_add_added_at_to_scraped_urls'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ### commands to upgrade database ###
+    
+    # Add epg_update_protected column to acestream_channels table
+    op.add_column('acestream_channels', 
+                  sa.Column('epg_update_protected', sa.Boolean(), 
+                            server_default=sa.text('FALSE'), 
+                            nullable=False))
+    
+    # Create epg_sources table
+    op.create_table(
+        'epg_sources',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('url', sa.String(), nullable=False),
+        sa.Column('enabled', sa.Boolean(), server_default=sa.text('TRUE'), nullable=False),
+        sa.Column('last_updated', sa.DateTime(), nullable=True),
+        sa.Column('error_count', sa.Integer(), server_default=sa.text('0'), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), 
+                  onupdate=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    # Create index for URL uniqueness
+    op.create_index(op.f('ix_epg_sources_url'), 'epg_sources', ['url'], unique=True)
+    
+    # Create epg_string_mappings table
+    op.create_table(
+        'epg_string_mappings',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('search_pattern', sa.String(), nullable=False),
+        sa.Column('epg_channel_id', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), 
+                  onupdate=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    # Create index for search pattern uniqueness
+    op.create_index(op.f('ix_epg_string_mappings_search_pattern'), 'epg_string_mappings', ['search_pattern'], unique=True)
+    
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    # ### commands to downgrade database ###
+    
+    # Drop the tables we created
+    op.drop_index(op.f('ix_epg_string_mappings_search_pattern'), table_name='epg_string_mappings')
+    op.drop_table('epg_string_mappings')
+    
+    op.drop_index(op.f('ix_epg_sources_url'), table_name='epg_sources')
+    op.drop_table('epg_sources')
+    
+    # Drop epg_update_protected column from acestream_channels table
+    op.drop_column('acestream_channels', 'epg_update_protected')
+    # ### end Alembic commands ###


### PR DESCRIPTION
This pull request introduces automation for retrieving channel data from an EPG guide.
These features can be managed from the Config tab.

⚠️ Note: This pull request is currently in draft to address any potential bugs, although it seems to be working well so far, i would like to test it further. Any feedback is welcome.

1️⃣ EPG Source System:

- Users must configure one or more XMLTV sources to retrieve channel data.
- Tested with: https://raw.githubusercontent.com/davidmuma/EPG_dobleM/refs/heads/master/guiatv.xml

2️⃣ Channel Mapping by Text Patterns:

- Implemented a manual mapping system based on text patterns.
- Users can also create exclusion rules to prevent specific channels from being mapped.

3️⃣ Automatic Channel Mapping:

- Introduced an automatic channel detection system based on name similarity.
- Users can set the similarity threshold, it is recommended to start with a threshold of 75%.
- I recommend starting with this method to map the channels and adjusting with text patterns if necessary.

4️⃣ Channel List:

- Users can block the channel data (in the channel data editing section) to prevent it from being affected by mapping tools.
- TV logos have been added to the channel table for better visualization.
- Color codes have been added to the edit icon to indicate the status of the channel data.

📌 Note: Code developed by Claude, my work has consisted mainly of keeping Claude in check to ensure everything aligns (which is no small feat, btw).