### PR TITLE
**Reason for the change:**

### DIFF
--- a/app/services/acestream_search_service.py
+++ b/app/services/acestream_search_service.py
@@ -112,13 +112,13 @@ class AcestreamSearchService:
                                 # Create a processed result with the required fields
                                 processed_item = {
                                     'name': result.get('name', 'Unnamed Channel'),
-                                    'id': item.get('infohash', ''), # Use the infohash as ID
+                                    'id': self.get_content_id(item.get('infohash')), # Get ID from infohash
                                     'categories': item.get('categories', []),
                                     'bitrate': item.get('bitrate', 0)
                                 }
                                 # Add any other useful fields from the item
                                 for key, value in item.items():
-                                    if key not in processed_item and key != 'infohash':
+                                    if key not in processed_item:
                                         processed_item[key] = value
                                 
                                 processed_results.append(processed_item)
@@ -209,4 +209,22 @@ class AcestreamSearchService:
         """
         if url.startswith('acestream://'):
             return url.split('acestream://')[1]
+        return None
+    
+    def get_content_id(self, infohash: str) -> Optional[str]:
+        try:
+            url = f"{self.engine_url}/server/api"
+            params = {
+                "api_version": 3,
+                "method": "get_content_id",
+                "infohash": infohash
+            }
+            response = requests.get(url, params=params, timeout=10)
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("result", {}).get("content_id")
+            else:
+                logger.error(f"Failed to get content_id for infohash {infohash}: status {response.status_code}")
+        except Exception as e:
+            logger.error(f"Exception in get_content_id for infohash {infohash}: {e}")
         return None


### PR DESCRIPTION
The application is designed to work with the `id` (content_id) field to identify Acestream channels, but the API only returns the `infohash`. Returning the `infohash` instead of the expected `id` breaks the application, as many features rely on having a valid `id`.

**Implemented solution:**

I added a function that retrieves the correct `content_id` from the `infohash` by calling the `/server/api` endpoint of the Acestream engine. This ensures that every search result includes the proper `id` field, maintaining compatibility with the rest of the application and avoiding breaking changes.

**Benefits:**

- The application continues to work as expected without requiring major refactoring.
- The solution is transparent and easy to maintain.
- Data consistency is preserved between backend and frontend.

**Request:**

Please consider accepting this change, as it resolves a structural issue without introducing breaking changes and keeps the project stable and reliable.