### PR TITLE
Fix ZeroNet URL scraping

### DIFF
--- a/app/scrapers/zeronet.py
+++ b/app/scrapers/zeronet.py
@@ -22,7 +22,9 @@ class ZeronetScraper(BaseScraper):
             'Accept-Encoding': 'gzip, deflate',
             'Connection': 'keep-alive',
             'DNT': '1',
-            'Upgrade-Insecure-Requests': '1'
+            'Upgrade-Insecure-Requests': '1',
+            # Fixes CORS
+            'Sec-Fetch-Mode': 'navigate'
         }
         self.cookie_jar = aiohttp.CookieJar()
 


### PR DESCRIPTION
Hi there!

First of all, thanks for creating this valuable project. It's been really useful for consuming Acestream channels via my Jellyfin instance without needing to manually fetch links.

I first did use a pair of regular HTTP sites, but after learning a little bit about what ZeroNet is, I decided to start using it, but to my surprise, scraping a ZeroNet m3u URL failed (link obfuscated for safety reasons):

> app.tasks.manager - INFO - Found 1 URLs to process
app.scrapers.zeronet - INFO - Detected direct M3U file URL: http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u
app.scrapers.zeronet - WARNING - Retry 1/5 for http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u. Error: . Waiting 2 seconds...
app.scrapers.zeronet - WARNING - Retry 2/5 for http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u. Error: . Waiting 4 seconds...
app.scrapers.zeronet - WARNING - Retry 3/5 for http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u. Error: . Waiting 8 seconds...
app.scrapers.zeronet - WARNING - Retry 4/5 for http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u. Error: . Waiting 16 seconds...
app.scrapers.zeronet - ERROR - Max retries reached for http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u. Last error:
app.scrapers.base - ERROR - Error scraping http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u:

After some investigation, I came across **Sec-Fetch-Mode** header which successfully fixes it:

> app.tasks.manager - INFO - Found 1 URLs to process
app.scrapers.zeronet - INFO - Detected direct M3U file URL: http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u
app.scrapers.zeronet - INFO - Successfully fetched M3U file content (44496 bytes)
app.scrapers.base - INFO - Processing direct M3U file: http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u
app.services.m3u_service - INFO - Extracted 205 channels with metadata from M3U content
app.scrapers.base - INFO - Extracted 202 channels from direct M3U file
app.scrapers.base - INFO - Successfully extracted 202 channels from http://127.0.0.1:43110/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/lista-ace.m3u
app.tasks.manager - INFO - URLs processed, re-associating channels by EPG ID...
app.tasks.manager - INFO - Starting automatic EPG association after scraping
app.services.tv_channel_service - INFO - Found 0 EPG channels to process
app.services.tv_channel_service - WARNING - No EPG channels found in the database. Please import EPG data first.
app.services.tv_channel_service - INFO - EPG Association complete: Created 0 TV channels, matched 0 acestreams, 175 remain unmatched
app.tasks.manager - DEBUG - EPG association completed: No new associations made

By the way, I've just checked **Sec-Fetch-Mode** header with *navigate* value. Please, feel free to propose [another value](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode) if it suits better.

Regards and Happy New Year!