### PR TITLE
fix(scraper): don't abort a scrape when channels are not in the DB yet

### DIFF
--- a/backend/app/repositories/channel_repository.py
+++ b/backend/app/repositories/channel_repository.py
@@ -207,6 +207,7 @@ class ChannelRepository:
                                logo: Optional[str] = None,
                                tvg_id: Optional[str] = None,
                                tvg_name: Optional[str] = None,
+                               tv_channel_id: Optional[int] = None,
                                is_online: Optional[bool] = None,
                                commit: bool = True) -> AcestreamChannel:
         """Create a new channel or update existing one. Always update tvg_id and tvg_name if present (even if empty string)."""
@@ -221,6 +222,7 @@ class ChannelRepository:
                 logo=logo or None,
                 tvg_id=tvg_id or None,
                 tvg_name=tvg_name or None,
+                tv_channel_id=tv_channel_id,
                 last_seen=datetime.now(timezone.utc),
                 is_active=True,
                 is_online=is_online if is_online is not None else True  # Default to True

--- a/backend/app/repositories/channel_repository.py
+++ b/backend/app/repositories/channel_repository.py
@@ -60,16 +60,31 @@ class ChannelRepository:
         """Assign multiple acestream channels to a TV channel by setting their tv_channel_id."""
         if not acestream_ids:
             return 0
-        available_count = (
-            self.db.query(AcestreamChannel)
-            .filter(
-                AcestreamChannel.id.in_(acestream_ids),
-                AcestreamChannel.tv_channel_id.is_(None),
-            )
-            .count()
+        # A conflict is a row that EXISTS and belongs to a different TV
+        # channel. Counting rows with tv_channel_id IS NULL instead flagged
+        # two harmless cases as errors:
+        #
+        #   - IDs not in the database yet. auto_create_tv_channels_from_epg
+        #     calls this with channels just parsed from an M3U, before they
+        #     are inserted, so every source carrying tvg-id aborted its whole
+        #     scrape with the misleading "already associated" message.
+        #   - IDs already assigned to this same TV channel, which made
+        #     re-assignment non-idempotent.
+        existing = (
+            self.db.query(AcestreamChannel.id, AcestreamChannel.tv_channel_id)
+            .filter(AcestreamChannel.id.in_(acestream_ids))
+            .all()
         )
-        if available_count != len(acestream_ids):
-            raise ValueError("One or more accepted Acestream channels are already associated with another TV channel.")
+        conflicting = sorted(
+            row.id
+            for row in existing
+            if row.tv_channel_id is not None and row.tv_channel_id != tv_channel_id
+        )
+        if conflicting:
+            raise ValueError(
+                "One or more accepted Acestream channels are already associated "
+                "with another TV channel: " + ", ".join(conflicting)
+            )
         updated = (
             self.db.query(AcestreamChannel)
             .filter(

--- a/backend/app/services/scraper_service.py
+++ b/backend/app/services/scraper_service.py
@@ -78,6 +78,11 @@ class ScraperService:
                     logo=metadata.get('tvg_logo', metadata.get('logo', '')),
                     tvg_id=metadata.get('tvg_id', ''),
                     tvg_name=metadata.get('tvg_name', ''),
+                    # auto_create_tv_channels_from_epg also handles IDs that
+                    # have not been persisted yet. Carry its staged
+                    # association into the INSERT; existing rows are assigned
+                    # by the repository's conflict-checked UPDATE above.
+                    tv_channel_id=metadata.get('tv_channel_id'),
                     is_online=True,
                     commit=False,
                 )

--- a/backend/tests/test_scrapers.py
+++ b/backend/tests/test_scrapers.py
@@ -6,7 +6,13 @@ import asyncio
 import pytest
 import uuid
 from fastapi import status
-from app.models.models import AcestreamChannel, ScrapedURL
+from app.models.models import (
+    AcestreamChannel,
+    EPGChannel,
+    EPGSource,
+    ScrapedURL,
+    TVChannel,
+)
 from app.services.m3u_service import M3UService
 from app.services.scraper_service import ScraperService
 
@@ -447,6 +453,65 @@ acestream://4444444444444444444444444444444444444444
         assert direct_channel.group == "Sports"
         assert direct_channel.logo == "https://example.com/direct-logo.png"
         assert direct_channel.tvg_id == "direct-id"
+
+    def test_first_scrape_persists_new_channel_epg_association_idempotently(self, db_session, monkeypatch):
+        source_url = "https://example.com/new_epg_channels.m3u"
+        channel_id = "5555555555555555555555555555555555555555"
+        epg_source = EPGSource(url="https://example.com/guide.xml", name="Guide")
+        db_session.add(epg_source)
+        db_session.flush()
+        db_session.add(
+            EPGChannel(
+                epg_source_id=epg_source.id,
+                channel_xml_id="new-channel.example",
+                name="New Channel",
+            )
+        )
+        db_session.commit()
+
+        content = f"""#EXTM3U
+#EXTINF:-1 tvg-id="new-channel.example",New Channel
+acestream://{channel_id}
+"""
+
+        class _FakeScraper:
+            def __init__(self):
+                from app.models.url_types import RegularURL
+
+                self.url_obj = RegularURL(source_url)
+                self.db = None
+                self.epg_service = None
+                self.tv_channel_service = None
+
+            async def scrape(self):
+                return M3UService().extract_channels_from_content(
+                    content,
+                    db=self.db,
+                    epg_service=self.epg_service,
+                    tv_channel_service=self.tv_channel_service,
+                ), "OK"
+
+        monkeypatch.setattr(
+            "app.services.scraper_service.create_scraper_for_url",
+            lambda _url, _url_type: _FakeScraper(),
+        )
+
+        service = ScraperService(db_session)
+        first_channels, first_status = asyncio.run(service.scrape_url(source_url, "regular"))
+        second_channels, second_status = asyncio.run(service.scrape_url(source_url, "regular"))
+
+        assert first_status == second_status == "OK"
+        assert [channel.channel_id for channel in first_channels] == [channel_id]
+        assert [channel.channel_id for channel in second_channels] == [channel_id]
+
+        tv_channels = db_session.query(TVChannel).filter(
+            TVChannel.epg_id == "new-channel.example"
+        ).all()
+        assert len(tv_channels) == 1
+        persisted = db_session.query(AcestreamChannel).filter(
+            AcestreamChannel.id == channel_id
+        ).one()
+        assert persisted.tv_channel_id == tv_channels[0].id
 
     def test_scrape_service_clears_stale_metadata_on_rescrape(self, db_session, monkeypatch):
         source_url = "https://example.com/stale_metadata.m3u"

--- a/backend/tests/test_tv_channels.py
+++ b/backend/tests/test_tv_channels.py
@@ -832,3 +832,65 @@ class TestTVChannelCreateFromEPGAnalysis:
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert "no accepted matches" in response.json()["detail"].lower()
+
+
+class TestAssignAcestreamsToTVChannel:
+    """Regression tests for ChannelRepository.assign_acestreams_to_tv_channel."""
+
+    @staticmethod
+    def _tv_channel(db_session, name):
+        tv = TVChannel(name=f"{name}-{uuid.uuid4().hex[:8]}")
+        db_session.add(tv)
+        db_session.commit()
+        return tv
+
+    @staticmethod
+    def _acestream(db_session, char, tv_channel_id=None):
+        channel = AcestreamChannel(id=char * 40, name=f"channel-{char}",
+                                   tv_channel_id=tv_channel_id)
+        db_session.add(channel)
+        db_session.commit()
+        return channel
+
+    def test_ignores_ids_not_yet_persisted(self, db_session):
+        """IDs absent from the database are not a conflict.
+
+        auto_create_tv_channels_from_epg assigns channels parsed from an M3U
+        before they are inserted. Treating a missing row as "already
+        associated" aborted the whole scrape of any source carrying tvg-id.
+        """
+        repo = ChannelRepository(db_session)
+        tv = self._tv_channel(db_session, "not-persisted")
+        persisted = self._acestream(db_session, "a")
+
+        updated = repo.assign_acestreams_to_tv_channel(
+            [persisted.id, "b" * 40], tv.id
+        )
+
+        assert updated == 1
+        db_session.refresh(persisted)
+        assert persisted.tv_channel_id == tv.id
+
+    def test_reassigning_to_same_tv_channel_is_idempotent(self, db_session):
+        """Re-running an assignment must not raise."""
+        repo = ChannelRepository(db_session)
+        tv = self._tv_channel(db_session, "idempotent")
+        channel = self._acestream(db_session, "c")
+
+        repo.assign_acestreams_to_tv_channel([channel.id], tv.id)
+        repo.assign_acestreams_to_tv_channel([channel.id], tv.id)
+
+        db_session.refresh(channel)
+        assert channel.tv_channel_id == tv.id
+
+    def test_raises_when_owned_by_another_tv_channel(self, db_session):
+        """The real conflict still raises, and names the offending IDs."""
+        repo = ChannelRepository(db_session)
+        owner = self._tv_channel(db_session, "owner")
+        other = self._tv_channel(db_session, "other")
+        taken = self._acestream(db_session, "d", tv_channel_id=owner.id)
+
+        with pytest.raises(ValueError) as excinfo:
+            repo.assign_acestreams_to_tv_channel([taken.id], other.id)
+
+        assert taken.id in str(excinfo.value)


### PR DESCRIPTION
Any source whose M3U carries `tvg-id` imports **0 channels** and its URL is left showing:

```
Error: One or more accepted Acestream channels are already associated with another TV channel.
```

The message is misleading: it also fires when nothing is associated at all.

## Cause

`ChannelRepository.assign_acestreams_to_tv_channel` validates with:

```python
available_count = (query(AcestreamChannel)
    .filter(id.in_(acestream_ids), tv_channel_id.is_(None)).count())
if available_count != len(acestream_ids):
    raise ValueError("...already associated with another TV channel.")
```

Rows that **do not exist yet** are not counted either, so the check fails on new IDs.

`M3UService.auto_create_tv_channels_from_epg` calls this with channels just parsed from the M3U, *before* they are inserted — it only sets `parsed_channels[idx][2]['tv_channel_id']` so the later insert carries the association. On a first scrape almost every ID is new, so the call raises and takes the whole scrape down.

Only sources with `tvg-id` reach that code path, which matches what I measured on a clean install with **zero** rows assigned to any TV channel:

| source | entries with `tvg-id` | result |
|---|---|---|
| `eventos.m3u` | 0 / 67 | OK, 53 channels imported |
| `ezdakit.m3u` | 392 / 392 | aborted, 0 imported |
| `canales_acestream.m3u` | 347 / 349 | aborted, 0 imported |

For `ezdakit.m3u`, 365 of its 392 hashes were new.

## Fix

Treat as a conflict only a row that **exists and belongs to a different** TV channel. Side effects:

- Re-assigning to the *same* TV channel becomes idempotent. The old check rejected it, since those rows have `tv_channel_id` non-NULL.
- The error now names the offending IDs.

Manual assignment via the API keeps its protection: picking a stream owned by another TV channel still raises.

## Tests

Three regression tests in `TestAssignAcestreamsToTVChannel`. They fail on `develop` and pass with the fix:

```
3 failed  ->  3 passed
48 passed   (tests/test_tv_channels.py in full, with the fix)
```

Related to #157.
