### PR TITLE
fix(ci): run validation in pinned sandbox

### DIFF
--- a/backend/tests/test_cleanup_runner_docker.py
+++ b/backend/tests/test_cleanup_runner_docker.py
@@ -64,7 +64,10 @@ def test_removes_only_old_transient_images_and_keeps_current(tmp_path: Path):
         "acestream-installer-test:apk-armeabi-v7a",
     }
     assert "docker image prune -f" in calls
-    assert "docker image prune -af --filter until=24h" in calls
+    assert (
+        "docker image prune -af --filter until=24h "
+        "--filter label!=org.acestream-scraper.ci.keep=true"
+    ) in calls
     prunes = [c for c in calls if c.startswith("docker buildx prune --builder")]
     assert "docker buildx prune --builder acestream-builder -f --max-used-space 3GB" in prunes
     assert "docker buildx prune --builder default -f --max-used-space 3GB" in prunes

--- a/backend/tests/test_http_scraper_ssl.py
+++ b/backend/tests/test_http_scraper_ssl.py
@@ -52,6 +52,9 @@ async def test_http_scraper_uses_certifi_ssl_context(monkeypatch):
         session_kwargs.update(kwargs)
         return MockSessionContext()
 
+    # URL-policy behavior is covered separately. Keep this SSL wiring test fully
+    # offline so it is deterministic in network-isolated CI.
+    monkeypatch.setattr(http_scraper_module, "validate_outbound_url", lambda _url: None)
     monkeypatch.setattr(http_scraper_module, "ssl", SimpleNamespace(create_default_context=fake_create_default_context), raising=False)
     monkeypatch.setattr(http_scraper_module, "certifi", SimpleNamespace(where=lambda: "/tmp/certifi.pem"), raising=False)
     monkeypatch.setattr(http_scraper_module.aiohttp, "ClientSession", fake_client_session)

--- a/docs/ops/jenkins-ci.md
+++ b/docs/ops/jenkins-ci.md
@@ -73,7 +73,7 @@ Pipeline enforcement in `jenkins/pr.Jenkinsfile` (multibranch job `acestream-scr
 
 Pipeline enforcement in `jenkins/develop.Jenkinsfile` (trusted job `acestream-scraper-develop`):
 
-- The job polls `develop`, requires checked-out `HEAD == origin/develop`, builds the trusted PR-runner image, and runs full application validation plus Docker/runtime smokes.
+- The job polls `develop`, requires checked-out `HEAD == origin/develop`, builds the trusted PR-runner image, and runs full application validation inside that pinned Python 3.12/Node runner with networking disabled. Compose validation and Docker/runtime smokes remain on the trusted host.
 - It repeats the `HEAD == origin/develop` comparison immediately before publication so an older queued build cannot move the channel backwards.
 - It then binds `dockerhub-publish` and runs `bash scripts/ci/run_jenkins_release.sh --channel develop`. Missing credentials or push failures fail the build.
   - Channel mode logs into Docker Hub, builds the four flavors multi-platform (`linux/amd64`, `linux/arm64`, `linux/arm/v7`) with `--push`, and verifies every pushed manifest.
@@ -750,7 +750,7 @@ Expected behavior:
 Create a Pipeline-from-SCM job inside the trusted publication subfolder. Point it at `*/develop` and set the script path to `jenkins/develop.Jenkinsfile`.
 
 - It polls SCM every five minutes, verifies the checkout is the current `origin/develop`, and refreshes the trusted PR-runner image.
-- It runs full application checks, dry-run architecture/publication policy, and the amd64/Acexy/ARM installer smokes.
+- It runs full application checks offline in the pinned runner, followed by trusted-host Compose validation, dry-run architecture/publication policy, and the amd64/Acexy/ARM installer smokes.
 - It checks `origin/develop` again immediately before publication.
 - Only then does it bind `dockerhub-publish` and `github-publish`, push the floating `:develop*` tags, and update the wiki and Pages.
 - Missing credentials and publication failures fail the build. The wiki's one-time uninitialized state remains `UNSTABLE` with an operator message.

--- a/jenkins/develop.Jenkinsfile
+++ b/jenkins/develop.Jenkinsfile
@@ -74,10 +74,30 @@ bash scripts/ci/publish_pages.sh --dry-run
       steps {
         sh '''#!/usr/bin/env bash
 set -euo pipefail
-backend/venv/bin/python scripts/phase_gates/phase3_gate_runner.py \
-  --profile full \
-  --json-output > phase3-gate-report-full.json
-bash scripts/ci/validate_runtime_contract.sh
+artifact_dir="$WORKSPACE/.ci-develop-artifacts"
+rm -rf "$artifact_dir"
+mkdir -p "$artifact_dir"
+host_uid="$(id -u)"
+host_gid="$(id -g)"
+docker run --rm \
+  --network none \
+  --read-only \
+  --user "$host_uid:$host_gid" \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  --pids-limit 1024 \
+  --memory 8g \
+  --memory-swap 8g \
+  --cpus 3 \
+  --tmpfs /tmp:rw,nosuid,nodev,size=1g \
+  --tmpfs /workspace:rw,nosuid,nodev,size=3g,mode=1777 \
+  --volume "$WORKSPACE:/source:ro" \
+  --volume "$artifact_dir:/artifacts:rw" \
+  --workdir /workspace \
+  "$PR_RUNNER_IMAGE" \
+  bash -c 'cp -R /source/. /workspace/ && CI_OUTPUT_DIR=/artifacts bash scripts/ci/run_develop_validation.sh'
+cp "$artifact_dir"/*.json .
+docker compose config -q
 '''
       }
       post {

--- a/jenkins/develop.Jenkinsfile
+++ b/jenkins/develop.Jenkinsfile
@@ -90,7 +90,7 @@ docker run --rm \
   --memory-swap 8g \
   --cpus 3 \
   --tmpfs /tmp:rw,nosuid,nodev,exec,size=1g \
-  --tmpfs /workspace:rw,nosuid,nodev,size=3g,mode=1777 \
+  --tmpfs /workspace:rw,nosuid,nodev,exec,size=3g,mode=1777 \
   --env GIT_CONFIG_COUNT=1 \
   --env GIT_CONFIG_KEY_0=safe.directory \
   --env GIT_CONFIG_VALUE_0=/workspace \

--- a/jenkins/develop.Jenkinsfile
+++ b/jenkins/develop.Jenkinsfile
@@ -91,6 +91,9 @@ docker run --rm \
   --cpus 3 \
   --tmpfs /tmp:rw,nosuid,nodev,size=1g \
   --tmpfs /workspace:rw,nosuid,nodev,size=3g,mode=1777 \
+  --env GIT_CONFIG_COUNT=1 \
+  --env GIT_CONFIG_KEY_0=safe.directory \
+  --env GIT_CONFIG_VALUE_0=/workspace \
   --volume "$WORKSPACE:/source:ro" \
   --volume "$artifact_dir:/artifacts:rw" \
   --workdir /workspace \

--- a/jenkins/develop.Jenkinsfile
+++ b/jenkins/develop.Jenkinsfile
@@ -89,7 +89,7 @@ docker run --rm \
   --memory 8g \
   --memory-swap 8g \
   --cpus 3 \
-  --tmpfs /tmp:rw,nosuid,nodev,size=1g \
+  --tmpfs /tmp:rw,nosuid,nodev,exec,size=1g \
   --tmpfs /workspace:rw,nosuid,nodev,size=3g,mode=1777 \
   --env GIT_CONFIG_COUNT=1 \
   --env GIT_CONFIG_KEY_0=safe.directory \

--- a/jenkins/pr.Jenkinsfile
+++ b/jenkins/pr.Jenkinsfile
@@ -96,7 +96,7 @@ docker run --rm --init \
   --memory 8g \
   --memory-swap 8g \
   --cpus 3 \
-  --tmpfs /tmp:rw,nosuid,nodev,size=1g \
+  --tmpfs /tmp:rw,nosuid,nodev,exec,size=1g \
   --tmpfs /workspace:rw,nosuid,nodev,size=3g,mode=1777 \
   --env CI=true \
   --env HOME=/tmp/ci-home \

--- a/jenkins/pr.Jenkinsfile
+++ b/jenkins/pr.Jenkinsfile
@@ -101,6 +101,9 @@ docker run --rm --init \
   --env CI=true \
   --env HOME=/tmp/ci-home \
   --env PYTHONDONTWRITEBYTECODE=1 \
+  --env GIT_CONFIG_COUNT=1 \
+  --env GIT_CONFIG_KEY_0=safe.directory \
+  --env GIT_CONFIG_VALUE_0=/workspace \
   --volume "$WORKSPACE:/source:ro" \
   --workdir /workspace \
   "$PR_RUNNER_IMAGE" \

--- a/jenkins/pr.Jenkinsfile
+++ b/jenkins/pr.Jenkinsfile
@@ -104,7 +104,7 @@ docker run --rm --init \
   --volume "$WORKSPACE:/source:ro" \
   --workdir /workspace \
   "$PR_RUNNER_IMAGE" \
-  bash -c 'cp -a /source/. /workspace/ && git show HEAD^1:scripts/ci/run_pr_validation.sh > /tmp/trusted-pr-validation.sh && bash /tmp/trusted-pr-validation.sh'
+  bash -c 'cp -R /source/. /workspace/ && git show HEAD^1:scripts/ci/run_pr_validation.sh > /tmp/trusted-pr-validation.sh && bash /tmp/trusted-pr-validation.sh'
 '''
       }
     }

--- a/jenkins/pr.Jenkinsfile
+++ b/jenkins/pr.Jenkinsfile
@@ -97,7 +97,7 @@ docker run --rm --init \
   --memory-swap 8g \
   --cpus 3 \
   --tmpfs /tmp:rw,nosuid,nodev,exec,size=1g \
-  --tmpfs /workspace:rw,nosuid,nodev,size=3g,mode=1777 \
+  --tmpfs /workspace:rw,nosuid,nodev,exec,size=3g,mode=1777 \
   --env CI=true \
   --env HOME=/tmp/ci-home \
   --env PYTHONDONTWRITEBYTECODE=1 \

--- a/jenkins/pr.Jenkinsfile
+++ b/jenkins/pr.Jenkinsfile
@@ -107,7 +107,7 @@ docker run --rm --init \
   --volume "$WORKSPACE:/source:ro" \
   --workdir /workspace \
   "$PR_RUNNER_IMAGE" \
-  bash -c 'cp -R /source/. /workspace/ && git show HEAD^1:scripts/ci/run_pr_validation.sh > /tmp/trusted-pr-validation.sh && bash /tmp/trusted-pr-validation.sh'
+  bash -c 'cp -R /source/. /workspace/ && trusted_script=/workspace/scripts/ci/.jenkins-trusted-pr-validation.sh && rm -f "$trusted_script" && git show HEAD^1:scripts/ci/run_pr_validation.sh > "$trusted_script" && bash "$trusted_script"'
 '''
       }
     }

--- a/scripts/ci/run_cutover_required_checks.sh
+++ b/scripts/ci/run_cutover_required_checks.sh
@@ -16,7 +16,11 @@ bash scripts/ci/assert_no_legacy_paths.sh --strict
 echo "Running canonical v2 test suite ($PROFILE)..."
 bash scripts/ci/run_v2_test_suite.sh --profile "$PROFILE"
 
-docker compose config >/dev/null
+if [[ "${CUTOVER_SKIP_COMPOSE:-0}" == "1" ]]; then
+  echo "Compose validation delegated to the trusted host."
+else
+  docker compose config >/dev/null
+fi
 
 if [[ "${CUTOVER_INCLUDE_MULTIARCH:-0}" == "1" ]]; then
   echo "Running optional multi-arch matrix validation (dry-run)..."

--- a/scripts/ci/run_develop_validation.sh
+++ b/scripts/ci/run_develop_validation.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT_DIR"
+
+if [[ ! -x /opt/backend-venv/bin/python || ! -d /opt/frontend-node_modules ]]; then
+  echo "Trusted develop runner dependencies are missing." >&2
+  exit 1
+fi
+
+OUTPUT_DIR="${CI_OUTPUT_DIR:-$ROOT_DIR}"
+mkdir -p "$OUTPUT_DIR"
+
+# Use the immutable dependency set built from develop. The copied frontend
+# modules live on the size-limited tmpfs because Vite and Jest may write caches.
+rm -rf backend/venv frontend/node_modules
+ln -s /opt/backend-venv backend/venv
+cp -R /opt/frontend-node_modules frontend/node_modules
+
+set +e
+CI_USE_PREINSTALLED_DEPS=1 CUTOVER_SKIP_COMPOSE=1 \
+  backend/venv/bin/python scripts/phase_gates/phase3_gate_runner.py \
+    --profile full \
+    --skip-command compose_smoke \
+    --json-output > "$OUTPUT_DIR/phase3-gate-report-full.json"
+gate_status=$?
+set -e
+
+if [[ -f phase3-phase1-full.json ]]; then
+  cp phase3-phase1-full.json "$OUTPUT_DIR/phase3-phase1-full.json"
+fi
+
+if [[ "$gate_status" -ne 0 ]]; then
+  exit "$gate_status"
+fi
+
+bash scripts/ci/validate_runtime_contract.sh
+echo "Pinned Python 3.12 develop validation passed."

--- a/scripts/ci/run_v2_test_suite.sh
+++ b/scripts/ci/run_v2_test_suite.sh
@@ -21,22 +21,30 @@ if [[ ! -d backend/venv ]]; then
   "$PYTHON_BIN" -m venv backend/venv
 fi
 
-if ! backend/venv/bin/pip install --upgrade pip >/dev/null; then
-  echo "WARN: Could not upgrade pip (offline or restricted network)."
-fi
-
-if ! backend/venv/bin/pip install -r backend/requirements.txt >/dev/null; then
-  echo "WARN: Could not install backend requirements from network."
-  FALLBACK_BACKEND_PYTEST=$(find . -type f -path "*/backend/venv/bin/pytest" ! -path "./backend/venv/*" | head -n 1 || true)
-  if [[ -n "${FALLBACK_BACKEND_PYTEST:-}" && -x "$FALLBACK_BACKEND_PYTEST" ]]; then
-    echo "INFO: Falling back to discovered backend virtualenv for checks."
-    BACKEND_PYTEST="$FALLBACK_BACKEND_PYTEST"
-  else
-    echo "ERROR: No fallback backend virtualenv available."
+if [[ "${CI_USE_PREINSTALLED_DEPS:-0}" == "1" ]]; then
+  if [[ ! -x backend/venv/bin/pytest ]]; then
+    echo "ERROR: CI_USE_PREINSTALLED_DEPS=1 requires backend/venv/bin/pytest."
     exit 1
   fi
-else
   BACKEND_PYTEST="backend/venv/bin/pytest"
+else
+  if ! backend/venv/bin/pip install --upgrade pip >/dev/null; then
+    echo "WARN: Could not upgrade pip (offline or restricted network)."
+  fi
+
+  if ! backend/venv/bin/pip install -r backend/requirements.txt >/dev/null; then
+    echo "WARN: Could not install backend requirements from network."
+    FALLBACK_BACKEND_PYTEST=$(find . -type f -path "*/backend/venv/bin/pytest" ! -path "./backend/venv/*" | head -n 1 || true)
+    if [[ -n "${FALLBACK_BACKEND_PYTEST:-}" && -x "$FALLBACK_BACKEND_PYTEST" ]]; then
+      echo "INFO: Falling back to discovered backend virtualenv for checks."
+      BACKEND_PYTEST="$FALLBACK_BACKEND_PYTEST"
+    else
+      echo "ERROR: No fallback backend virtualenv available."
+      exit 1
+    fi
+  else
+    BACKEND_PYTEST="backend/venv/bin/pytest"
+  fi
 fi
 
 echo "Running canonical backend suite ($PROFILE)..."
@@ -61,7 +69,12 @@ PYTHONPATH=backend backend/venv/bin/python backend/scripts/dump_openapi.py
 echo "Running canonical frontend suite ($PROFILE)..."
 (
   cd frontend
-  if ! npm ci >/dev/null; then
+  if [[ "${CI_USE_PREINSTALLED_DEPS:-0}" == "1" ]]; then
+    if [[ ! -x node_modules/.bin/jest ]]; then
+      echo "ERROR: CI_USE_PREINSTALLED_DEPS=1 requires frontend/node_modules."
+      exit 1
+    fi
+  elif ! npm ci >/dev/null; then
     echo "WARN: npm ci failed (offline or restricted network)."
     FALLBACK_NODE_MODULES=$(find .. -type d -path "*/frontend/node_modules" ! -path "../frontend/node_modules" | head -n 1 || true)
     if [[ -n "${FALLBACK_NODE_MODULES:-}" && -d "$FALLBACK_NODE_MODULES" ]]; then

--- a/scripts/phase_gates/check_workflow_publish_guard.py
+++ b/scripts/phase_gates/check_workflow_publish_guard.py
@@ -67,6 +67,7 @@ def read(rel: str) -> str:
 def main() -> int:
     pr_jenkinsfile = read("jenkins/pr.Jenkinsfile")
     develop_jenkinsfile = read("jenkins/develop.Jenkinsfile")
+    develop_validation = read("scripts/ci/run_develop_validation.sh")
     phase5_config = read("scripts/phase_gates/phase5_gate_config.yaml")
     release_sh = read("scripts/ci/run_jenkins_release.sh")
     release_jenkinsfile = read("jenkins/release.Jenkinsfile")
@@ -107,6 +108,13 @@ def main() -> int:
         ("develop pipeline builds the trusted fork runner",
          "docker/ci/pr-runner.Dockerfile" in develop_jenkinsfile
          and "acestream-scraper-pr-ci:develop" in develop_jenkinsfile),
+        ("develop tests use the pinned runner without network or dependency installs",
+         "--network none" in develop_jenkinsfile
+         and "scripts/ci/run_develop_validation.sh" in develop_jenkinsfile
+         and "CI_USE_PREINSTALLED_DEPS=1" in develop_validation
+         and "CUTOVER_SKIP_COMPOSE=1" in develop_validation
+         and "--skip-command compose_smoke" in develop_validation
+         and "docker compose config -q" in develop_jenkinsfile),
         ("release script channel mode never emits a version tag or :latest",
          all(tag in channel_plan for tag in CHANNEL_TAGS)
          and "pipepito/acestream-scraper:latest" not in channel_plan

--- a/scripts/phase_gates/check_workflow_publish_guard.py
+++ b/scripts/phase_gates/check_workflow_publish_guard.py
@@ -91,6 +91,8 @@ def main() -> int:
          and "--cap-drop ALL" in pr_jenkinsfile
          and "no-new-privileges" in pr_jenkinsfile
          and '$WORKSPACE:/source:ro' in pr_jenkinsfile
+         and "GIT_CONFIG_KEY_0=safe.directory" in pr_jenkinsfile
+         and "GIT_CONFIG_VALUE_0=/workspace" in pr_jenkinsfile
          and "git show HEAD^1:scripts/ci/run_pr_validation.sh" in pr_jenkinsfile
          and "runnerInputsChanged" in pr_jenkinsfile
          and "env.CHANGE_FORK" in pr_jenkinsfile),

--- a/scripts/phase_gates/phase3_gate_runner.py
+++ b/scripts/phase_gates/phase3_gate_runner.py
@@ -45,12 +45,14 @@ def render_command(raw_command: str, python_bin: str) -> str:
 def build_summary(profile: str, config_version: str, results: List[Dict[str, Any]]) -> Dict[str, Any]:
     blocking_failures = [item["id"] for item in results if item["blocking"] and item["status"] == "failed"]
     non_blocking_failures = [item["id"] for item in results if not item["blocking"] and item["status"] == "failed"]
+    skipped_commands = [item["id"] for item in results if item["status"] == "skipped"]
     return {
         "profile": profile,
         "config_version": config_version,
         "passed": len(blocking_failures) == 0,
         "blocking_failures": blocking_failures,
         "non_blocking_failures": non_blocking_failures,
+        "skipped_commands": skipped_commands,
         "results": results,
     }
 
@@ -87,6 +89,12 @@ def main() -> int:
     parser.add_argument("--profile", default="quick", help="Gate profile to run (quick|full).")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to gate config file.")
     parser.add_argument("--json-output", action="store_true", help="Print machine-readable JSON summary.")
+    parser.add_argument(
+        "--skip-command",
+        action="append",
+        default=[],
+        help="Record a command as delegated instead of running it (repeatable).",
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[2]
@@ -103,11 +111,30 @@ def main() -> int:
     profile = profiles[args.profile]
     commands = profile.get("commands", [])
     results: List[Dict[str, Any]] = []
+    skip_commands = set(args.skip_command)
+    known_commands = {command["id"] for command in commands}
+    unknown_skips = sorted(skip_commands - known_commands)
+    if unknown_skips:
+        print(f"Unknown command id(s) requested for skip: {', '.join(unknown_skips)}", file=sys.stderr)
+        return 2
 
     python_bin = resolve_python_bin()
 
     for command in commands:
         rendered_command = render_command(command["command"], python_bin)
+        if command["id"] in skip_commands:
+            results.append({
+                "id": command["id"],
+                "description": command.get("description", ""),
+                "command": rendered_command,
+                "blocking": bool(command.get("blocking", True)),
+                "status": "skipped",
+                "exit_code": 0,
+                "duration_ms": 0,
+                "stdout_tail": "Delegated to the trusted Jenkins host.",
+                "stderr_tail": "",
+            })
+            continue
         started = time.time()
         completed = run_command(rendered_command, repo_root)
         duration_ms = int((time.time() - started) * 1000)


### PR DESCRIPTION
Fixes the two issues found by the first live split-pipeline run: non-root workspace copying no longer preserves the tmpfs root timestamp, and broad develop validation runs offline inside the pinned Python 3.12/Node runner. Compose and privileged runtime checks remain on the trusted Jenkins host. Also makes two full-suite tests deterministic under the new cleanup and network-isolation rules.