### PR TITLE
fix(ci): resolve trust from target ref

### DIFF
--- a/jenkins/pr.Jenkinsfile
+++ b/jenkins/pr.Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
           def runnerInputsChanged = sh(
             returnStatus: true,
             script: '''#!/usr/bin/env bash
-git diff --quiet HEAD^1 -- \
+git diff --quiet "refs/remotes/origin/${CHANGE_TARGET}"...HEAD -- \
   backend/requirements.txt \
   frontend/package.json \
   frontend/package-lock.json \
@@ -104,10 +104,11 @@ docker run --rm --init \
   --env GIT_CONFIG_COUNT=1 \
   --env GIT_CONFIG_KEY_0=safe.directory \
   --env GIT_CONFIG_VALUE_0=/workspace \
+  --env "PR_TARGET_REF=refs/remotes/origin/$CHANGE_TARGET" \
   --volume "$WORKSPACE:/source:ro" \
   --workdir /workspace \
   "$PR_RUNNER_IMAGE" \
-  bash -c 'cp -R /source/. /workspace/ && trusted_script=/workspace/scripts/ci/.jenkins-trusted-pr-validation.sh && rm -f "$trusted_script" && git show HEAD^1:scripts/ci/run_pr_validation.sh > "$trusted_script" && bash "$trusted_script"'
+  bash -c 'cp -R /source/. /workspace/ && trusted_script=/workspace/scripts/ci/.jenkins-trusted-pr-validation.sh && rm -f "$trusted_script" && git show "${PR_TARGET_REF}:scripts/ci/run_pr_validation.sh" > "$trusted_script" && bash "$trusted_script"'
 '''
       }
     }

--- a/scripts/phase_gates/check_workflow_publish_guard.py
+++ b/scripts/phase_gates/check_workflow_publish_guard.py
@@ -93,7 +93,8 @@ def main() -> int:
          and '$WORKSPACE:/source:ro' in pr_jenkinsfile
          and "GIT_CONFIG_KEY_0=safe.directory" in pr_jenkinsfile
          and "GIT_CONFIG_VALUE_0=/workspace" in pr_jenkinsfile
-         and "git show HEAD^1:scripts/ci/run_pr_validation.sh" in pr_jenkinsfile
+         and 'PR_TARGET_REF=refs/remotes/origin/$CHANGE_TARGET' in pr_jenkinsfile
+         and 'git show "${PR_TARGET_REF}:scripts/ci/run_pr_validation.sh"' in pr_jenkinsfile
          and "runnerInputsChanged" in pr_jenkinsfile
          and "env.CHANGE_FORK" in pr_jenkinsfile),
         ("PR pipeline rejects PRs into main that do not come from develop",


### PR DESCRIPTION
Use Jenkins' explicit target-branch remote ref for dependency-diff checks and for loading the trusted PR orchestrator. This removes synthetic merge-parent ordering assumptions and makes the same credential-free pipeline work for both origin and fork PRs.