### PR TITLE
Add Acexy playback routing and direct send-to-player actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,16 @@ not part of the required PR gate; see `e2e/AGENTS.md` before running it.
   workflow that both agents need to know.
 - Do not turn dated CI status into timeless documentation. Label snapshots with a
   date and commit, and include the command/source future agents should recheck.
+
+## Playback routing
+
+`GET/PUT /api/v1/config/playback-routing` persists `use_acexy` and `acexy_url`
+as one JSON setting. Direct mode is the default. Web-player and tuner factories
+use `playback_client_from_settings`; engine health/probes remain direct.
+Acexy mode reads MPEG-TS from `/ace/getstream?id=…` with no PID or engine JSON
+start/stat/stop calls. The session retains its Acexy ownership flag across
+configuration changes so cleanup never stops another proxy client. Remote
+players use the server relay in Acexy mode, bypassing saved custom link formats;
+direct mode honors their formats and adds a unique PID to direct engine links.
+Existing shared browser sessions retain their route until teardown. See
+`wiki/Remote-Players.md#playback-routing` for operator behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,3 +184,16 @@ shares sessions only for matching channel/audio choices (default equals track ze
 Input audio metadata is discovered from ffmpeg input logging; output tracks are
 excluded. Choosing audio restarts that viewer, follows normal capacity/grace rules,
 and does not alter another viewer's session or a remote player's raw source URL.
+
+## Playback routing
+
+`GET/PUT /api/v1/config/playback-routing` persists `use_acexy` and `acexy_url`
+as one JSON setting. Direct mode is the default. Web-player and tuner factories
+use `playback_client_from_settings`; engine health/probes remain direct.
+Acexy mode reads MPEG-TS from `/ace/getstream?id=…` with no PID or engine JSON
+start/stat/stop calls. The session retains its Acexy ownership flag across
+configuration changes so cleanup never stops another proxy client. Remote
+players use the server relay in Acexy mode, bypassing saved custom link formats;
+direct mode honors their formats and adds a unique PID to direct engine links.
+Existing shared browser sessions retain their route until teardown. See
+`wiki/Remote-Players.md#playback-routing` for operator behavior.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -88,3 +88,16 @@ PYTHONPATH=backend alembic -c backend/migrations/alembic.ini upgrade head
 - Browser session sharing includes the selected audio track. An audio change must
   not change another viewer's session, evade capacity limits, or leak an engine
   session. Parse input audio tracks only, excluding ffmpeg output declarations.
+
+## Playback routing
+
+`GET/PUT /api/v1/config/playback-routing` persists `use_acexy` and `acexy_url`
+as one JSON setting. Direct mode is the default. Web-player and tuner factories
+use `playback_client_from_settings`; engine health/probes remain direct.
+Acexy mode reads MPEG-TS from `/ace/getstream?id=…` with no PID or engine JSON
+start/stat/stop calls. The session retains its Acexy ownership flag across
+configuration changes so cleanup never stops another proxy client. Remote
+players use the server relay in Acexy mode, bypassing saved custom link formats;
+direct mode honors their formats and adds a unique PID to direct engine links.
+Existing shared browser sessions retain their route until teardown. See
+`wiki/Remote-Players.md#playback-routing` for operator behavior.

--- a/backend/app/api/endpoints/config.py
+++ b/backend/app/api/endpoints/config.py
@@ -17,6 +17,7 @@ from app.schemas.config import (
     DashboardConfigResponse,
     DashboardConfigUpdate,
     PublicBaseUrlUpdate,
+    PlaybackRouting,
     RescrapeIntervalUpdate,
     SettingResponse,
     SettingsResponse,
@@ -37,6 +38,16 @@ def _validate_boolean_string(value: str, setting_name: str) -> None:
     valid_values = {"true", "false", "True", "False", "1", "0"}
     if value not in valid_values:
         raise HTTPException(status_code=422, detail=f"Invalid boolean value for {setting_name}")
+
+
+@router.get("/playback-routing", response_model=PlaybackRouting)
+def get_playback_routing(config_service: ConfigService = Depends(get_config_service)):
+    return config_service.get_playback_routing()
+
+
+@router.put("/playback-routing", response_model=PlaybackRouting)
+def update_playback_routing(update: PlaybackRouting, config_service: ConfigService = Depends(get_config_service)):
+    return config_service.set_playback_routing(update)
 
 
 @router.get("/appid", response_model=SettingResponse)

--- a/backend/app/api/endpoints/tuner.py
+++ b/backend/app/api/endpoints/tuner.py
@@ -22,7 +22,7 @@ from app.api.error_handlers import APIError
 from app.config.database import SessionLocal, get_db
 from app.repositories.settings_repository import SettingsRepository
 from app.schemas.tuner import TunerSettingsResponse, TunerSettingsUpdate, TunerStatusResponse, TunerUrls
-from app.services.engine_client import EngineClient, EngineRefusedError, EngineUnavailableError, engine_url_from_settings
+from app.services.engine_client import EngineClient, EngineRefusedError, EngineUnavailableError, playback_client_from_settings
 from app.services.epg_service import EPGService
 from app.services.player_service import player_service
 from app.services.public_url_service import resolve_public_base_url
@@ -47,7 +47,7 @@ def _engine() -> EngineClient:
     """
     db = SessionLocal()
     try:
-        return EngineClient(engine_url_from_settings(SettingsRepository(db)))
+        return playback_client_from_settings(SettingsRepository(db))
     finally:
         db.close()
 

--- a/backend/app/repositories/settings_repository.py
+++ b/backend/app/repositories/settings_repository.py
@@ -13,6 +13,7 @@ class SettingsRepository:
     # Constants for settings keys
     BASE_URL = 'base_url'
     ACE_ENGINE_URL = 'ace_engine_url'
+    PLAYBACK_ROUTING = 'playback_routing'
     RESCRAPE_INTERVAL = 'rescrape_interval'
     ADDPID = 'addpid'
     EPG_REFRESH_INTERVAL = 'epg_refresh_interval'
@@ -26,6 +27,7 @@ class SettingsRepository:
 
     # Constants for default values
     DEFAULT_BASE_URL = 'acestream://'
+    DEFAULT_PLAYBACK_ROUTING = '{"use_acexy":false,"acexy_url":"http://localhost:8080"}'
     # A container that runs no engine of its own points at an external one through ACE_ENGINE_URL
     # (legacy alias ACESTREAM_ENGINE_URL); the Settings page can still override it per database.
     DEFAULT_ACE_ENGINE_URL = os.environ.get('ACE_ENGINE_URL') or os.environ.get('ACESTREAM_ENGINE_URL') or 'http://localhost:6878'

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -1,6 +1,26 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+class PlaybackRouting(BaseModel):
+    use_acexy: bool = Field(False, description="Route web, tuner and remote-player playback through Acexy")
+    acexy_url: str = Field("http://localhost:8080", description="HTTP(S) origin where the backend reaches Acexy in MPEG-TS mode")
+
+    @field_validator("acexy_url")
+    @classmethod
+    def validate_acexy_url(cls, value: str) -> str:
+        from app.services.public_url_service import normalize_public_base_url
+
+        if any(char.isspace() for char in value.strip()):
+            raise ValueError("Acexy URL must not contain whitespace")
+        try:
+            normalized = normalize_public_base_url(value)
+        except ValueError as exc:
+            raise ValueError("Acexy URL must be an HTTP(S) origin without a path, query or credentials") from exc
+        if not normalized:
+            raise ValueError("Acexy URL is required")
+        return normalized
 
 class BaseUrlUpdate(BaseModel):
     """Schema for updating the base URL for Acestream links"""

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 import re
 
 from app.repositories.settings_repository import SettingsRepository
+from app.schemas.config import PlaybackRouting
 from app.services.public_url_service import InvalidPublicBaseUrl, normalize_public_base_url
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,14 @@ class ConfigService:
     def get_ace_engine_url(self) -> str:
         """Get the Acestream Engine URL"""
         return self.settings_repo.get_setting(SettingsRepository.ACE_ENGINE_URL)
+
+    def get_playback_routing(self) -> PlaybackRouting:
+        return PlaybackRouting.model_validate_json(self.settings_repo.get_setting(SettingsRepository.PLAYBACK_ROUTING))
+
+    def set_playback_routing(self, routing: PlaybackRouting) -> PlaybackRouting:
+        if not self.settings_repo.set_setting(SettingsRepository.PLAYBACK_ROUTING, routing.model_dump_json(), "Playback routing"):
+            raise HTTPException(status_code=500, detail="Failed to save playback routing")
+        return routing
 
     def set_ace_engine_url(self, url: str) -> bool:
         """Set the Acestream Engine URL"""

--- a/backend/app/services/engine_client.py
+++ b/backend/app/services/engine_client.py
@@ -15,6 +15,7 @@ from urllib.parse import urlsplit
 import httpx
 
 from app.repositories.settings_repository import SettingsRepository
+from app.schemas.config import PlaybackRouting
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,7 @@ class EngineSession:
     stat_url: str
     command_url: str
     is_live: bool
+    managed_by_acexy: bool = False
 
 
 @dataclass(frozen=True)
@@ -84,6 +86,13 @@ def engine_url_from_settings(settings_repo: SettingsRepository) -> str:
     return url.rstrip("/")
 
 
+def playback_client_from_settings(settings_repo: SettingsRepository) -> "EngineClient":
+    routing = PlaybackRouting.model_validate_json(settings_repo.get_setting(SettingsRepository.PLAYBACK_ROUTING))
+    if routing.use_acexy:
+        return EngineClient(routing.acexy_url, use_acexy=True)
+    return EngineClient(engine_url_from_settings(settings_repo))
+
+
 class EngineClient:
     """Talks to one engine over HTTP.
 
@@ -93,8 +102,9 @@ class EngineClient:
     never closed here: whoever opened it closes it.
     """
 
-    def __init__(self, engine_url: str, client: Optional[httpx.Client] = None):
+    def __init__(self, engine_url: str, client: Optional[httpx.Client] = None, *, use_acexy: bool = False):
         self.engine_url = engine_url.rstrip("/")
+        self.use_acexy = use_acexy
         self._owns_client = client is None
         self._client = client or httpx.Client(timeout=START_TIMEOUT)
 
@@ -134,6 +144,11 @@ class EngineClient:
         return body
 
     def start(self, content_id: str, pid: Optional[str] = None) -> EngineSession:
+        if self.use_acexy:
+            # Acexy owns multiplexing and engine sessions. Reading/closing this
+            # stream is its lifecycle; never send JSON/start/stop or a PID.
+            url = str(httpx.URL(f"{self.engine_url}/ace/getstream", params={"id": content_id}))
+            return EngineSession(content_id, "", url, "", "", True, managed_by_acexy=True)
         pid = pid or new_pid()
         body = self._get_json(
             f"{self.engine_url}/ace/getstream",
@@ -152,6 +167,8 @@ class EngineClient:
             raise EngineUnavailableError(f"Engine start response is incomplete: {body}") from exc
 
     def stop(self, session: EngineSession) -> None:
+        if session.managed_by_acexy:
+            return
         # Merge rather than replace: the engine may hand back a command_url
         # that already carries a token or session id in its query.
         url = httpx.URL(session.command_url).copy_merge_params({"method": "stop"})
@@ -160,7 +177,9 @@ class EngineClient:
         except httpx.HTTPError as exc:
             logger.warning("Engine stop for %s failed: %s", session.content_id, exc)
 
-    def stat(self, session: EngineSession) -> EngineStats:
+    def stat(self, session: EngineSession) -> Optional[EngineStats]:
+        if session.managed_by_acexy:
+            return None
         body = self._get_json(session.stat_url, timeout=STAT_TIMEOUT)
         return EngineStats(
             status=str(body.get("status") or "unknown"),

--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -29,7 +29,7 @@ from app.services.engine_client import (
     EngineSession,
     EngineStats,
     EngineUnavailableError,
-    engine_url_from_settings,
+    playback_client_from_settings,
 )
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,7 @@ def _engine_from_settings() -> EngineClient:
 
     db = SessionLocal()
     try:
-        return EngineClient(engine_url_from_settings(SettingsRepository(db)))
+        return playback_client_from_settings(SettingsRepository(db))
     finally:
         db.close()
 
@@ -430,7 +430,7 @@ class PlayerService:
     async def _refresh_stats(self, session: PlayerSession) -> None:
         """Read one session's engine statistics; failures are best effort."""
         engine_session = session.engine_session
-        if session.state not in ("starting", "ready") or engine_session is None:
+        if session.state not in ("starting", "ready") or engine_session is None or engine_session.managed_by_acexy:
             return
         try:
             session.stats = await run_in_threadpool(self._engine_call, lambda engine: engine.stat(engine_session))

--- a/backend/app/services/remote_players/service.py
+++ b/backend/app/services/remote_players/service.py
@@ -14,6 +14,9 @@ from app.config.settings import get_settings
 from app.models.models import RemotePlayer
 from app.repositories.base_url_repository import BaseUrlRepository
 from app.repositories.remote_player_repository import RemotePlayerRepository
+from app.repositories.settings_repository import SettingsRepository
+from app.schemas.config import PlaybackRouting
+from app.services.engine_client import new_pid
 from app.services.playlist_service import PlaylistService
 from app.services.public_url_service import host_warnings
 from app.services.tuner_network import TunerNetworkGate
@@ -192,8 +195,12 @@ class RemotePlayerService:
     def _stream_pattern(self, player: RemotePlayer) -> Optional[str]:
         """The player's own stream link format, or None when it gets the relay
         URL — including when the format has been deleted: SQLite runs without
-        foreign keys, so the id can dangle."""
-        if player.base_url_id is None:
+        foreign keys, so the id can dangle. Acexy routing always uses the relay
+        so every external player follows the global routing choice."""
+        routing = PlaybackRouting.model_validate_json(
+            SettingsRepository(self.db).get_setting(SettingsRepository.PLAYBACK_ROUTING)
+        )
+        if routing.use_acexy or player.base_url_id is None:
             return None
         entry = BaseUrlRepository(self.db).get(player.base_url_id)
         return entry.pattern if entry is not None else None
@@ -203,7 +210,14 @@ class RemotePlayerService:
         backend relay URL (spec 6.3)."""
         pattern = self._stream_pattern(player)
         if pattern is not None:
-            return PlaylistService._stream_link(pattern, content_id, None)
+            pid = new_pid()
+            url = PlaylistService._stream_link(pattern.replace("{pid}", pid), content_id, None)
+            parsed = httpx.URL(url)
+            if parsed.scheme in ("http", "https") and parsed.path.rstrip("/").endswith(("/ace/getstream", "/ace/manifest.m3u8")):
+                # Each send owns a playback session, even for patterns with a
+                # missing or fixed PID. Keep unrelated query options intact.
+                url = str(parsed.copy_remove_param("sid").copy_merge_params({"pid": pid}))
+            return url
         return f"{public_base_url.rstrip('/')}/tuner/stream/{content_id}.ts"
 
     def play_warnings(self, player: RemotePlayer, public_base_url: str) -> List[str]:

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -2764,6 +2764,24 @@
         "title": "MigrationProgress",
         "type": "object"
       },
+      "PlaybackRouting": {
+        "properties": {
+          "acexy_url": {
+            "default": "http://localhost:8080",
+            "description": "HTTP(S) origin where the backend reaches Acexy in MPEG-TS mode",
+            "title": "Acexy Url",
+            "type": "string"
+          },
+          "use_acexy": {
+            "default": false,
+            "description": "Route web, tuner and remote-player playback through Acexy",
+            "title": "Use Acexy",
+            "type": "boolean"
+          }
+        },
+        "title": "PlaybackRouting",
+        "type": "object"
+      },
       "PlayerCapabilities": {
         "properties": {
           "ffmpeg_available": {
@@ -8727,6 +8745,68 @@
           }
         },
         "summary": "Update Epg Refresh Interval",
+        "tags": [
+          "config",
+          "config"
+        ]
+      }
+    },
+    "/api/v1/config/playback-routing": {
+      "get": {
+        "operationId": "get_playback_routing_api_v1_config_playback_routing_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaybackRouting"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Playback Routing",
+        "tags": [
+          "config",
+          "config"
+        ]
+      },
+      "put": {
+        "operationId": "update_playback_routing_api_v1_config_playback_routing_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlaybackRouting"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaybackRouting"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Playback Routing",
         "tags": [
           "config",
           "config"

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -332,3 +332,23 @@ class TestConfigIntegration:
             assert data["key"] == endpoint
             assert data["value"] is not None
             assert data["value"] != ""
+
+
+def test_playback_routing_defaults_and_round_trip(alembic_client):
+    path = '/api/v1/config/playback-routing'
+    assert alembic_client.get(path).json() == {'use_acexy': False, 'acexy_url': 'http://localhost:8080'}
+    saved = {'use_acexy': True, 'acexy_url': 'http://proxy.lan:8080/'}
+    result = alembic_client.put(path, json=saved)
+    assert result.status_code == 200
+    assert result.json() == {'use_acexy': True, 'acexy_url': 'http://proxy.lan:8080'}
+    assert alembic_client.get(path).json() == result.json()
+    assert alembic_client.put(path, json={**saved, 'use_acexy': False}).json()['use_acexy'] is False
+
+
+@pytest.mark.parametrize('url', ['', 'file:///tmp/stream', 'http://proxy/path', 'http://user:secret@proxy', 'http://bad host', 'http://[::1'])
+def test_playback_routing_rejects_invalid_origin_without_saving(alembic_client, url):
+    path = '/api/v1/config/playback-routing'
+    before = alembic_client.get(path).json()
+    response = alembic_client.put(path, json={'use_acexy': True, 'acexy_url': url})
+    assert response.status_code == 422
+    assert alembic_client.get(path).json() == before

--- a/backend/tests/test_engine_client.py
+++ b/backend/tests/test_engine_client.py
@@ -161,3 +161,32 @@ def test_start_refuses_a_playback_url_that_is_not_http(bad):
 
     with pytest.raises(EngineUnavailableError, match="playback_url"):
         EngineClient("http://engine:6878", client=_client(handler)).start(CID)
+
+
+def test_acexy_owns_session_lifecycle_without_pid_or_engine_api():
+    def handler(request):
+        pytest.fail(f'Unexpected engine API call: {request.url.path}')
+    direct = EngineClient('http://engine:6878', client=_client(handler))
+    proxy = EngineClient('http://acexy:8080', client=_client(handler), use_acexy=True)
+    session = proxy.start(CID, pid='must-not-be-sent')
+    assert session.playback_url == f'http://acexy:8080/ace/getstream?id={CID}'
+    assert session.pid == '' and session.managed_by_acexy
+    # Reconfiguring routing while playback is active must not stop Acexy's
+    # shared engine session or try to use engine statistics for it.
+    direct.stop(session)
+    assert direct.stat(session) is None
+    proxy.stop(session)
+    assert proxy.stat(session) is None
+
+
+def test_playback_factory_uses_saved_routing_but_engine_checks_remain_direct(db_session):
+    from app.repositories.settings_repository import SettingsRepository
+    from app.services.engine_client import playback_client_from_settings
+    repo = SettingsRepository(db_session)
+    repo.set_setting('ace_engine_url', 'http://engine:6878')
+    with playback_client_from_settings(repo) as client:
+        assert client.engine_url == 'http://engine:6878' and not client.use_acexy
+    repo.set_setting('playback_routing', '{"use_acexy":true,"acexy_url":"http://proxy:8080"}')
+    with playback_client_from_settings(repo) as client:
+        assert client.engine_url == 'http://proxy:8080' and client.use_acexy
+    assert engine_url_from_settings(repo) == 'http://engine:6878'

--- a/backend/tests/test_player_service.py
+++ b/backend/tests/test_player_service.py
@@ -27,7 +27,7 @@ class FakeSettings:
         self.FFMPEG_BINARY_PATH = ""
 
 
-def _engine(handler=None):
+def _engine(handler=None, use_acexy=False):
     def default(request):
         p = request.url.path
         if p == "/ace/getstream":
@@ -35,17 +35,17 @@ def _engine(handler=None):
         if "/ace/stat/" in p:
             return httpx.Response(200, json={"response": {"status": "dl", "peers": 3, "speed_down": 500, "speed_up": 10}, "error": None})
         return httpx.Response(200, text="ok")
-    return EngineClient("http://engine:6878", client=httpx.Client(transport=httpx.MockTransport(handler or default)))
+    return EngineClient("http://engine:6878", client=httpx.Client(transport=httpx.MockTransport(handler or default)), use_acexy=use_acexy)
 
 
 @pytest.fixture
 def make_service(tmp_path, monkeypatch):
-    def factory(mode="normal", ffmpeg=str(FAKE_FFMPEG), handler=None, **settings):
+    def factory(mode="normal", ffmpeg=str(FAKE_FFMPEG), handler=None, use_acexy=False, **settings):
         monkeypatch.setenv("FAKE_FFMPEG_MODE", mode)
         clock = {"now": 1000.0}
         svc = PlayerService(
             settings_getter=lambda: FakeSettings(tmp_path / "hls", **settings),
-            engine_factory=lambda: _engine(handler),
+            engine_factory=lambda: _engine(handler, use_acexy),
             ffmpeg_path=ffmpeg,
             monotonic=lambda: clock["now"],
         )
@@ -595,11 +595,32 @@ def test_audio_selection_isolated_and_tracks_discovered_from_input(make_service,
             assert same is original
             alternate = await svc.open_session(IH, audio_index=1)
             assert alternate is not original
+            assert len(original.engine_session.pid) == 32
+            assert alternate.engine_session.pid != original.engine_session.pid
             assert alternate.audio_index == 1 and original.audio_index is None
             assert original.viewers == 2
             assert await svc.open_session(IH, audio_index=1) is alternate
             argv = svc.ffmpeg_argv('http://engine/media', Path('/tmp/hls'), audio_index=1)
             assert '0:a:1' in argv and '0:a:0?' not in argv
+        finally:
+            await svc.stop()
+    asyncio.run(run())
+
+
+def test_web_player_reads_acexy_and_leaves_shared_session_management_to_proxy(make_service):
+    def handler(request):
+        pytest.fail(f'Unexpected direct engine API call: {request.url.path}')
+    svc = make_service(handler=handler, use_acexy=True)
+    async def run():
+        await svc.start()
+        try:
+            session = await svc.open_session(IH)
+            assert session.engine_session.managed_by_acexy
+            assert session.engine_session.playback_url == f'http://engine:6878/ace/getstream?id={IH}'
+            assert await _wait(lambda: svc.hls_ready(session))
+            await svc.tick()
+            assert session.state == 'ready' and session.stats is None
+            assert await svc.open_session(IH) is session
         finally:
             await svc.stop()
     asyncio.run(run())

--- a/backend/tests/test_remote_player_service.py
+++ b/backend/tests/test_remote_player_service.py
@@ -75,7 +75,9 @@ def test_resolve_stream_url_relay_and_pattern(alembic_db_session):
     relay = svc.repo.create(name="relay", kind="vlc", host="192.168.1.20", port=8080, username=None, password="pw", base_url_id=None)
     custom = svc.repo.create(name="custom", kind="vlc", host="192.168.1.21", port=8080, username=None, password="pw", base_url_id=pattern.id)
     assert svc.resolve_stream_url(relay, IH, "http://scraper.lan:8000") == f"http://scraper.lan:8000/tuner/stream/{IH}.ts"
-    assert svc.resolve_stream_url(custom, IH, "http://scraper.lan:8000") == f"http://192.168.1.10:8080/ace/getstream?id={IH}"
+    url = httpx.URL(svc.resolve_stream_url(custom, IH, "http://scraper.lan:8000"))
+    assert url.params["id"] == IH
+    assert len(url.params["pid"]) == 32
 
 
 def test_play_and_commands_go_through_the_driver(alembic_db_session):
@@ -197,3 +199,50 @@ def test_a_failing_call_still_closes_its_client(alembic_db_session):
     with pytest.raises(PlayerAuthError):
         svc.status(player)
     assert len(clients) == 1 and clients[0].is_closed
+
+
+@pytest.mark.parametrize('pattern', [
+    'http://engine:6878/ace/getstream?id={channel_id}&pid={pid}&token=keep',
+    'http://engine:6878/ace/getstream?id={channel_id}&token=keep',
+    'http://engine:6878/ace/manifest.m3u8?id={channel_id}&pid=fixed&sid=old&token=keep',
+    'http://engine:6878/ace/getstream?token=keep&id=',
+])
+def test_direct_engine_sends_have_independent_pids(alembic_db_session, pattern):
+    from app.repositories.base_url_repository import BaseUrlRepository
+    svc = _service(alembic_db_session)
+    entry = BaseUrlRepository(alembic_db_session).create('Direct', pattern)
+    player = svc.repo.create(name='Direct', kind='vlc', host='192.168.1.20', port=8080,
+                             username=None, password='pw', base_url_id=entry.id)
+    urls = [httpx.URL(svc.resolve_stream_url(player, IH, 'http://scraper:8000')) for _ in range(2)]
+    assert urls[0].params['pid'] != urls[1].params['pid']
+    for url in urls:
+        assert len(url.params['pid']) == 32
+        assert url.params['id'] == IH
+        assert url.params['token'] == 'keep'
+        assert 'sid' not in url.params
+        assert len(url.params.get_list('pid')) == 1
+
+
+@pytest.mark.parametrize('pattern', ['acestream://{channel_id}', 'https://proxy/stream/{channel_id}?token=keep'])
+def test_non_engine_formats_are_preserved(alembic_db_session, pattern):
+    from app.repositories.base_url_repository import BaseUrlRepository
+    svc = _service(alembic_db_session)
+    entry = BaseUrlRepository(alembic_db_session).create('Custom', pattern)
+    player = svc.repo.create(name='Custom', kind='vlc', host='192.168.1.20', port=8080,
+                             username=None, password='pw', base_url_id=entry.id)
+    assert svc.resolve_stream_url(player, IH, 'http://scraper:8000') == pattern.replace('{channel_id}', IH)
+
+
+def test_acexy_routing_overrides_player_format_and_checks_relay_access(alembic_db_session):
+    from app.repositories.settings_repository import SettingsRepository
+    from app.repositories.base_url_repository import BaseUrlRepository
+    repo = SettingsRepository(alembic_db_session)
+    repo.set_setting('playback_routing', '{"use_acexy":true,"acexy_url":"http://proxy:8080"}')
+    svc = _service(alembic_db_session)
+    entry = BaseUrlRepository(alembic_db_session).create('Direct', 'http://engine:6878/ace/getstream?id={channel_id}&pid={pid}')
+    player = svc.repo.create(name='Direct', kind='vlc', host='192.168.1.20', port=8080,
+                             username=None, password='pw', base_url_id=entry.id)
+    assert svc.resolve_stream_url(player, IH, 'http://localhost:8000') == f'http://localhost:8000/tuner/stream/{IH}.ts'
+    assert 'localhost' in svc.play_warnings(player, 'http://localhost:8000')
+    repo.set_setting('playback_routing', '{"use_acexy":false,"acexy_url":"http://proxy:8080"}')
+    assert httpx.URL(svc.resolve_stream_url(player, IH, 'http://scraper:8000')).params['pid']

--- a/backend/tests/test_stream_relay.py
+++ b/backend/tests/test_stream_relay.py
@@ -387,3 +387,36 @@ def test_registry_tracks_and_reaps():
     assert registry.count_active() == 0
     assert registry.reap_finished(older_than_seconds=0) == 1
     assert registry.active() == []
+
+
+def test_simultaneous_relays_for_same_content_use_distinct_pids():
+    calls = []
+    engine, factory = _engine_and_factory(_fake_engine(calls))
+
+    async def run():
+        first = relay_engine_stream(engine, IH, 'tuner', client_factory=factory)
+        second = relay_engine_stream(engine, IH, 'external-player', client_factory=factory)
+        try:
+            assert await anext(first) == BODY
+            assert await anext(second) == BODY
+            starts = [httpx.URL(url) for _, url in calls if '/ace/getstream?' in url]
+            assert len(starts) == 2
+            assert starts[0].params['pid'] != starts[1].params['pid']
+            assert all(len(url.params['pid']) == 32 for url in starts)
+        finally:
+            await first.aclose()
+            await second.aclose()
+    asyncio.run(run())
+
+
+def test_acexy_relay_reads_bytes_without_pid_json_or_stop():
+    calls = []
+    def handler(request):
+        calls.append(request.url)
+        assert request.url.path == '/ace/getstream'
+        assert dict(request.url.params) == {'id': IH}
+        return httpx.Response(200, content=BODY, headers={'Content-Type': 'video/mp2t'})
+    engine, factory = _engine_and_factory(handler)
+    engine.use_acexy = True
+    assert _collect(relay_engine_stream(engine, IH, 'tuner', client_factory=factory)) == BODY
+    assert len(calls) == 1

--- a/e2e/mobile/live-tv.spec.ts
+++ b/e2e/mobile/live-tv.spec.ts
@@ -115,3 +115,31 @@ test('audio track selection requests the chosen language', async ({ page }) => {
   await expect.poll(() => selectedAudio).toEqual([1]);
   await page.getByRole('button', { name: 'Close', exact: true }).click();
 });
+
+for (const mode of ['light', 'dark']) {
+  test(`${mode}: send to an external player without starting browser playback`, async ({ page }) => {
+    const { starts } = await fixtures(page);
+    const sends: unknown[] = [];
+    await page.route('**/api/v1/remote-players', (route) => route.fulfill({ json: [{ id: 7, name: 'Living room', kind: 'vlc' }] }));
+    await page.route('**/api/v1/remote-players/7/play', (route) => {
+      sends.push(route.request().postDataJSON());
+      return route.fulfill({ json: { warnings: [] } });
+    });
+    await page.addInitScript((value) => localStorage.setItem('app-theme-mode', value), mode);
+    await page.goto('/live-tv');
+    for (const title of ['Arena TV', 'Independent live stream']) {
+      await page.getByRole('button', { name: `Send to player ${title}`, exact: true }).focus();
+      await page.keyboard.press('Enter');
+      await page.getByRole('menuitem', { name: 'Living room (VLC)' }).click();
+      await expect(page.getByText(`Sent ${title} to Living room.`)).toBeVisible();
+    }
+    expect(sends).toEqual([
+      { content_id: streams[0].id, title: 'Arena TV' },
+      { content_id: orphan.id, title: 'Independent live stream' },
+    ]);
+    expect(starts).toEqual([]);
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    await page.screenshot({ path: test.info().outputPath(`send-to-player-${mode}.png`), fullPage: true });
+  });
+}

--- a/e2e/mobile/playback-routing.spec.ts
+++ b/e2e/mobile/playback-routing.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+for (const mode of ['light', 'dark']) {
+  test(`${mode}: save Acexy routing and switch back to direct playback`, async ({ page }) => {
+    let routing = { use_acexy: false, acexy_url: 'http://localhost:8080' };
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.route('**/api/**', async (route) => {
+      const path = new URL(route.request().url()).pathname.replace('/api/v1', '');
+      let data: unknown = {};
+      if (path === '/startup') data = { status: 'ready', phase: 'Ready to use', events: [] };
+      else if (path === '/config/playback-routing') {
+        if (route.request().method() === 'PUT') routing = route.request().postDataJSON();
+        data = routing;
+      } else if (path === '/config/acestream_status') data = { status: 'online', message: 'Engine online' };
+      else if (path === '/config/ace_engine_url') data = { value: 'http://localhost:6878' };
+      else if (path === '/config/rescrape_interval' || path === '/config/epg_refresh_interval') data = { value: '24' };
+      else if (path.startsWith('/config/')) data = { value: 'false' };
+      else if (path === '/base-urls') data = [];
+      await route.fulfill({ json: data });
+    });
+    await page.addInitScript((value) => localStorage.setItem('app-theme-mode', value), mode);
+    await page.goto('/settings');
+    const toggle = page.getByRole('checkbox', { name: 'Route playback through Acexy' });
+    await expect(toggle).not.toBeChecked();
+    await toggle.check();
+    await page.getByRole('textbox', { name: 'Acexy URL' }).fill('http://proxy.lan:8080');
+    await page.getByRole('button', { name: 'Save playback routing' }).click();
+    await expect(page.getByText('Playback routing saved.')).toBeVisible();
+    expect(routing).toEqual({ use_acexy: true, acexy_url: 'http://proxy.lan:8080' });
+    await page.reload();
+    await expect(toggle).toBeChecked();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    await page.screenshot({ path: test.info().outputPath(`routing-${mode}.png`), fullPage: true });
+    await toggle.uncheck();
+    await page.getByRole('button', { name: 'Save playback routing' }).click();
+    await expect(page.getByText('Playback routing saved.')).toBeVisible();
+    expect(routing.use_acexy).toBe(false);
+    expect(errors).toEqual([]);
+  });
+}

--- a/frontend/src/__tests__/LiveTV.test.tsx
+++ b/frontend/src/__tests__/LiveTV.test.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from '@mui/material/styles';
 import LiveTV from '../pages/LiveTV';
 import { createAppTheme } from '../theme';
 
+const mockSend = jest.fn();
+const mockPlayers = jest.fn();
+jest.mock('../hooks/useRemotePlayers', () => ({
+  useRemotePlayers: () => mockPlayers(),
+  usePlayOnRemotePlayer: () => ({ mutateAsync: mockSend }),
+}));
 const mockCatalog = jest.fn();
 const mockUnassigned = jest.fn();
 jest.mock('../hooks/useTVChannels', () => ({ useTVChannelCatalog: () => mockCatalog(), useTVChannel: () => ({}) }));
@@ -15,6 +21,8 @@ const renderPage = () => render(<MemoryRouter><ThemeProvider theme={createAppThe
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockPlayers.mockReturnValue({ data: [{ id: 7, name: 'Living room', kind: 'vlc' }] });
+  mockSend.mockResolvedValue({ warnings: [] });
   mockCatalog.mockReturnValue({ data: [
     { id: 1, name: 'Watchable', is_active: true, acestream_channels: [{ id: 'one' }] },
     { id: 2, name: 'Empty channel', is_active: true, acestream_channels: [] },
@@ -61,4 +69,29 @@ it('shows loading and empty states independently', () => {
   renderPage();
   expect(screen.getByText(/No active TV channels with streams yet/)).toBeInTheDocument();
   expect(screen.getByText('No online streams without a channel.')).toBeInTheDocument();
+});
+
+it.each([['Watchable', 'one'], ['Independent', 'raw']])('sends %s directly without opening the web player', async (title, contentId) => {
+  renderPage();
+  fireEvent.click(screen.getByRole('button', { name: `Send to player ${title}` }));
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Living room (VLC)' }));
+  await waitFor(() => expect(mockSend).toHaveBeenCalledWith({ id: 7, contentId, title }));
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  expect(await screen.findByText(`Sent ${title} to Living room.`)).toBeInTheDocument();
+});
+
+it('offers setup when no external players are saved', () => {
+  mockPlayers.mockReturnValue({ data: [] });
+  renderPage();
+  fireEvent.click(screen.getByRole('button', { name: 'Send to player Watchable' }));
+  expect(screen.getByRole('menuitem', { name: /Add a player/ })).toHaveAttribute('href', '/integrations');
+});
+
+it('reports a failed send without opening the web player', async () => {
+  mockSend.mockRejectedValue(new Error('offline'));
+  renderPage();
+  fireEvent.click(screen.getByRole('button', { name: 'Send to player Watchable' }));
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Living room (VLC)' }));
+  expect(await screen.findByText('Could not reach the player.')).toBeInTheDocument();
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });

--- a/frontend/src/__tests__/PlaybackRoutingFields.test.tsx
+++ b/frontend/src/__tests__/PlaybackRoutingFields.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import PlaybackRoutingFields from '../components/player/PlaybackRoutingFields';
+import { usePlaybackRouting, useUpdatePlaybackRouting } from '../hooks/useConfig';
+
+jest.mock('../hooks/useConfig');
+const query = usePlaybackRouting as jest.Mock;
+const update = useUpdatePlaybackRouting as jest.Mock;
+const mutate = jest.fn();
+beforeEach(() => {
+  jest.clearAllMocks();
+  query.mockReturnValue({ data: { use_acexy: false, acexy_url: 'http://localhost:8080' } });
+  update.mockReturnValue({ mutate, reset: jest.fn() });
+});
+it('saves the proxy route and restores direct mode', () => {
+  render(<PlaybackRoutingFields />);
+  expect(screen.getByRole('button', { name: 'Save playback routing' })).toBeDisabled();
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Route playback through Acexy' }));
+  fireEvent.change(screen.getByLabelText('Acexy URL', { exact: false }), { target: { value: 'http://proxy:8080' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save playback routing' }));
+  expect(mutate).toHaveBeenLastCalledWith({ use_acexy: true, acexy_url: 'http://proxy:8080' }, expect.anything());
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Route playback through Acexy' }));
+  fireEvent.click(screen.getByRole('button', { name: 'Save playback routing' }));
+  expect(mutate).toHaveBeenLastCalledWith({ use_acexy: false, acexy_url: 'http://proxy:8080' }, expect.anything());
+});
+it('reports loading, read failures with retry, and save failures', () => {
+  query.mockReturnValue({ isLoading: true });
+  const view = render(<PlaybackRoutingFields />);
+  expect(screen.getByRole('progressbar', { name: 'Loading playback routing' })).toBeInTheDocument();
+  const refetch = jest.fn();
+  query.mockReturnValue({ isError: true, refetch });
+  view.rerender(<PlaybackRoutingFields />);
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+  expect(refetch).toHaveBeenCalled();
+  query.mockReturnValue({ data: { use_acexy: false, acexy_url: 'http://localhost:8080' } });
+  update.mockReturnValue({ mutate, reset: jest.fn(), isError: true, error: new Error('Save failed') });
+  view.rerender(<PlaybackRoutingFields />);
+  expect(screen.getByText('Something went wrong. Try again.')).toBeInTheDocument();
+});

--- a/frontend/src/__tests__/Settings.test.tsx
+++ b/frontend/src/__tests__/Settings.test.tsx
@@ -30,6 +30,8 @@ describe('Settings page', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (configHooks.usePlaybackRouting as jest.Mock).mockReturnValue({ data: { use_acexy: false, acexy_url: 'http://localhost:8080' } });
+    (configHooks.useUpdatePlaybackRouting as jest.Mock).mockReturnValue({ mutate: succeedingMutate(), reset: jest.fn(), isPending: false });
     (configHooks.useBaseUrl as jest.Mock).mockReturnValue({ data: 'acestream://', isLoading: false });
     (configHooks.useUpdateBaseUrl as jest.Mock).mockReturnValue({ mutate: succeedingMutate(), isPending: false });
     (configHooks.useAceEngineUrl as jest.Mock).mockReturnValue({ data: 'http://localhost:6878', isLoading: false });
@@ -197,4 +199,15 @@ describe('Settings page', () => {
     expect(appIdToggle).not.toBeChecked();
     expect(screen.getByText(/failed to update appid setting/i)).toBeInTheDocument();
   });
+it('saves Acexy routing and its backend URL together', async () => {
+  const mutate = jest.fn();
+  (configHooks.usePlaybackRouting as jest.Mock).mockReturnValue({ data: { use_acexy: false, acexy_url: 'http://localhost:8080' } });
+  (configHooks.useUpdatePlaybackRouting as jest.Mock).mockReturnValue({ mutate, reset: jest.fn() });
+  render(<ThemeProvider theme={createAppTheme('light')}><TestMemoryRouter><Settings /></TestMemoryRouter></ThemeProvider>);
+  fireEvent.click(await screen.findByRole('checkbox', { name: 'Route playback through Acexy' }));
+  fireEvent.change(screen.getByLabelText('Acexy URL', { exact: false }), { target: { value: 'http://proxy.lan:8080' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save playback routing' }));
+  expect(mutate).toHaveBeenCalledWith({ use_acexy: true, acexy_url: 'http://proxy.lan:8080' }, expect.anything());
+});
+
 });

--- a/frontend/src/__tests__/playbackRoutingService.test.ts
+++ b/frontend/src/__tests__/playbackRoutingService.test.ts
@@ -1,0 +1,12 @@
+import apiClient from '../services/apiClient';
+import { configService } from '../services/configService';
+jest.mock('../services/apiClient', () => ({ __esModule: true, default: { get: jest.fn(), put: jest.fn() } }));
+it('reads and saves typed playback routing', async () => {
+  const data = { use_acexy: true, acexy_url: 'http://proxy:8080' };
+  (apiClient.get as jest.Mock).mockResolvedValue({ data });
+  (apiClient.put as jest.Mock).mockResolvedValue({ data });
+  expect(await configService.getPlaybackRouting()).toEqual(data);
+  expect(await configService.updatePlaybackRouting(data)).toEqual(data);
+  expect(apiClient.get).toHaveBeenCalledWith('/v1/config/playback-routing');
+  expect(apiClient.put).toHaveBeenCalledWith('/v1/config/playback-routing', data);
+});

--- a/frontend/src/components/integrations/RemotePlayerDialog.tsx
+++ b/frontend/src/components/integrations/RemotePlayerDialog.tsx
@@ -259,6 +259,7 @@ const RemotePlayerDialog: React.FC<RemotePlayerDialogProps> = ({ open, player, p
                 ))}
               </Select>
             </FormControl>
+            <Alert severity="info">When Acexy routing is enabled in Settings, playback uses the server relay instead of this link format.</Alert>
             {probe ? <Alert severity={probe.severity}>{probe.text}</Alert> : null}
           </Stack>
         </DialogContent>

--- a/frontend/src/components/player/PlayOnMenu.tsx
+++ b/frontend/src/components/player/PlayOnMenu.tsx
@@ -9,6 +9,7 @@ import { describePlaySent, describeRemotePlayerError, type PlayerNotify } from '
 export interface PlayOnMenuProps {
   contentId: string;
   title: string;
+  label?: string;
   /** Rendered as a button that opens the menu (default). */
   variant?: 'button';
   onDone?: () => void;
@@ -22,7 +23,7 @@ export interface PlayOnMenuProps {
 const KIND_LABEL: Record<string, string> = { vlc: 'VLC', vlc_android: 'VLC Android', kodi: 'Kodi' };
 
 /** "Play on…": send a channel to a saved VLC/Kodi player. */
-const PlayOnMenu: React.FC<PlayOnMenuProps> = ({ contentId, title, onDone, notify }) => {
+const PlayOnMenu: React.FC<PlayOnMenuProps> = ({ contentId, title, label, onDone, notify }) => {
   const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [notice, setNotice] = useState<{ message: string; severity: 'success' | 'warning' | 'error' } | null>(null);
   const { data: players = [], isLoading } = useRemotePlayers();
@@ -51,10 +52,11 @@ const PlayOnMenu: React.FC<PlayOnMenuProps> = ({ contentId, title, onDone, notif
         startIcon={<CastRoundedIcon />}
         onClick={(event) => setAnchor(event.currentTarget)}
         aria-haspopup="menu"
+        aria-label={label ? `${label} ${title}` : undefined}
         aria-expanded={Boolean(anchor)}
         disabled={isLoading || play.isPending}
       >
-        Play on…
+        {label ?? 'Play on…'}
       </Button>
       <Menu anchorEl={anchor} open={Boolean(anchor)} onClose={() => setAnchor(null)}>
         {players.length === 0

--- a/frontend/src/components/player/PlaybackRoutingFields.tsx
+++ b/frontend/src/components/player/PlaybackRoutingFields.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { Alert, Button, FormControlLabel, LinearProgress, Stack, Switch, TextField, Typography } from '@mui/material';
+import { usePlaybackRouting, useUpdatePlaybackRouting } from '../../hooks/useConfig';
+import type { PlaybackRouting } from '../../services/configService';
+import { getErrorMessage } from '../../utils/errorUtils';
+
+const PlaybackRoutingFields: React.FC = () => {
+  const query = usePlaybackRouting();
+  const save = useUpdatePlaybackRouting();
+  const [draft, setDraft] = useState<PlaybackRouting | null>(null);
+  const [saved, setSaved] = useState(false);
+  const routing = draft ?? query.data;
+  if (query.isLoading) return <LinearProgress aria-label="Loading playback routing" />;
+  if (query.isError || !routing) return <Alert severity="error" action={<Button onClick={() => void query.refetch()}>Retry</Button>}>Unable to load playback routing.</Alert>;
+
+  const change = (value: Partial<PlaybackRouting>) => {
+    setDraft({ ...routing, ...value });
+    setSaved(false);
+    save.reset();
+  };
+  return <Stack component="form" aria-label="Playback routing" spacing={1.5} onSubmit={(event: React.FormEvent) => {
+    event.preventDefault();
+    save.mutate(routing, { onSuccess: () => { setDraft(null); setSaved(true); } });
+  }}>
+    <FormControlLabel label="Route playback through Acexy" control={<Switch checked={routing.use_acexy ?? false}
+      disabled={save.isPending} onChange={(_event, checked) => change({ use_acexy: checked })} />} />
+    <Typography variant="body2" color="text.secondary">
+      {routing.use_acexy
+        ? 'Web playback, tuners and external players use Acexy through this server. Acexy manages shared streams and player IDs. Saved player link formats are bypassed.'
+        : 'Web playback and tuner relays connect directly to the engine with a unique player ID. External players use the server relay or their saved link format.'}
+    </Typography>
+    <TextField label="Acexy URL" size="small" value={routing.acexy_url ?? ''} required type="url"
+      disabled={save.isPending} onChange={(event) => change({ acexy_url: event.target.value })}
+      helperText="Address reachable from the backend, e.g. http://localhost:8080. Acexy must be running in MPEG-TS mode."
+      sx={{ maxWidth: 480 }} />
+    <Typography variant="caption" color="text.secondary">Applies to new sessions. Current sessions keep their route until they close. This setting does not start or stop the Acexy service.</Typography>
+    {save.isError ? <Alert severity="error">{getErrorMessage(save.error)}</Alert> : null}
+    {saved ? <Alert severity="success">Playback routing saved.</Alert> : null}
+    <Button type="submit" variant="outlined" disabled={!draft || save.isPending} sx={{ alignSelf: 'flex-start' }}>
+      {save.isPending ? 'Saving…' : 'Save playback routing'}
+    </Button>
+  </Stack>;
+};
+
+export default PlaybackRoutingFields;

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient, UseQueryOptions } from '@tanstack/react-query';
-import { configService, HealthResponse, Stats, StatusResponse, TvChannelStats } from '../services/configService';
+import { configService, HealthResponse, Stats, StatusResponse, TvChannelStats, type PlaybackRouting } from '../services/configService';
 
 type QueryOpts<T> = Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
 
@@ -141,4 +141,16 @@ export const useStats = (options: QueryOpts<Stats> = {}) => {
  */
 export const useTvChannelStats = (options: QueryOpts<TvChannelStats> = {}) => {
   return useQuery<TvChannelStats>({ queryKey: ['stats', 'tv-channels'], queryFn: configService.getTvChannelStats, ...options });
+};
+
+export const usePlaybackRouting = () => useQuery({ queryKey: ['playbackRouting'], queryFn: configService.getPlaybackRouting });
+export const useUpdatePlaybackRouting = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (routing: PlaybackRouting) => configService.updatePlaybackRouting(routing),
+    onSuccess: (routing) => {
+      queryClient.setQueryData(['playbackRouting'], routing);
+      void queryClient.invalidateQueries({ queryKey: ['allSettings'] });
+    },
+  });
 };

--- a/frontend/src/pages/LiveTV.tsx
+++ b/frontend/src/pages/LiveTV.tsx
@@ -12,6 +12,7 @@ import PageHeader from '../components/layout/PageHeader';
 import StatusLine from '../components/StatusLine';
 import ChannelGuide from '../components/player/ChannelGuide';
 import ChannelPlayerDialog from '../components/player/ChannelPlayerDialog';
+import PlayOnMenu from '../components/player/PlayOnMenu';
 
 const PAGE_SIZE = 12;
 
@@ -57,13 +58,16 @@ const LiveTV: React.FC = () => {
       </Alert> : null}
       <Box>
         {channels.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE).map((channel) => <Box component="article" key={channel.id} sx={{ py: 2, borderBottom: 1, borderColor: 'divider' }}>
-          <Stack direction="row" spacing={1.5} alignItems="center" sx={{ mb: 1 }}>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ mb: 1 }}>
             <Box sx={{ flex: 1, minWidth: 0 }}>
               <Typography component="h3" variant="h6" sx={{ overflowWrap: 'anywhere' }}>{channel.channel_number != null ? `${channel.channel_number}. ` : ''}{channel.name}</Typography>
               <Typography variant="body2" color="text.secondary">{channel.acestream_channels.length ? `${channel.acestream_channels.length} stream${channel.acestream_channels.length === 1 ? '' : 's'}` : 'No streams attached'}{channel.category ? ` · ${channel.category}` : ''}</Typography>
             </Box>
-            <Button variant="contained" startIcon={<PlayArrowRounded />} disabled={!channel.acestream_channels.length}
-              aria-label={`Watch ${channel.name}`} onClick={() => { const next = new URLSearchParams(params); next.set('channel', String(channel.id)); setParams(next); }}>Watch</Button>
+            <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+              <Button variant="contained" startIcon={<PlayArrowRounded />} disabled={!channel.acestream_channels.length}
+                aria-label={`Watch ${channel.name}`} onClick={() => { const next = new URLSearchParams(params); next.set('channel', String(channel.id)); setParams(next); }}>Watch</Button>
+              <PlayOnMenu contentId={channel.acestream_channels[0].id} title={channel.name} label="Send to player" />
+            </Stack>
           </Stack>
           <ChannelGuide channel={channel} now={now} compact />
         </Box>)}
@@ -78,12 +82,15 @@ const LiveTV: React.FC = () => {
       {!unassigned.isLoading && !unassigned.isError && !unassigned.data?.items.length ? <Alert severity="info" sx={{ mt: 2 }}>
         {streamSearch ? 'No online unassigned streams match this search.' : 'No online streams without a channel.'}
       </Alert> : null}
-      {unassigned.data?.items.map((stream) => <Stack component="article" key={stream.id} direction="row" spacing={1.5} alignItems="center" sx={{ py: 2, borderBottom: 1, borderColor: 'divider' }}>
+      {unassigned.data?.items.map((stream) => <Stack component="article" key={stream.id} direction={{ xs: 'column', sm: 'row' }} spacing={1.5} alignItems={{ xs: 'stretch', sm: 'center' }} sx={{ py: 2, borderBottom: 1, borderColor: 'divider' }}>
         <Box sx={{ flex: 1, minWidth: 0 }}>
           <Typography component="h3" variant="h6" sx={{ overflowWrap: 'anywhere' }}>{stream.name}</Typography>
           <Typography variant="body2" color="text.secondary">Online at last check · {stream.last_checked ? formatRelativeTime(stream.last_checked) : 'Check time unavailable'}{stream.group ? ` · ${stream.group}` : ''}</Typography>
         </Box>
-        <Button variant="outlined" startIcon={<PlayArrowRounded />} aria-label={`Watch ${stream.name}`} onClick={() => setPlayingStream(stream)}>Watch</Button>
+        <Stack direction="row" spacing={0.5} sx={{ flexShrink: 0 }}>
+          <Button variant="outlined" startIcon={<PlayArrowRounded />} aria-label={`Watch ${stream.name}`} onClick={() => setPlayingStream(stream)}>Watch</Button>
+          <PlayOnMenu contentId={stream.id} title={stream.name} label="Send to player" />
+        </Stack>
       </Stack>)}
       {(unassigned.data?.total ?? 0) > PAGE_SIZE ? <Pagination aria-label="Unassigned stream pages" count={streamPageCount} page={streamPage} onChange={(_event, value) => setStreamPage(value)} size="small" siblingCount={0} sx={{ my: 2 }} /> : null}
     </ContentSection>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import PlaybackRoutingFields from '../components/player/PlaybackRoutingFields';
 import {
   Alert,
   Box,
@@ -527,6 +528,7 @@ const Settings: React.FC = () => {
               </Button>
             </Stack>
           </form>
+          <PlaybackRoutingFields />
         </Stack>
       </ContentSection>
 

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -1,4 +1,7 @@
 import apiClient from './apiClient';
+import type { components } from '../types/api-generated';
+
+export type PlaybackRouting = components['schemas']['PlaybackRouting'];
 
 export interface Setting {
   value: string;
@@ -46,6 +49,14 @@ export interface Stats {
 const BASE_URL = '/v1/config';
 
 export const configService = {
+  getPlaybackRouting: async (): Promise<PlaybackRouting> => {
+    const response = await apiClient.get<PlaybackRouting>(`${BASE_URL}/playback-routing`);
+    return response.data;
+  },
+  updatePlaybackRouting: async (routing: PlaybackRouting): Promise<PlaybackRouting> => {
+    const response = await apiClient.put<PlaybackRouting>(`${BASE_URL}/playback-routing`, routing);
+    return response.data;
+  },
   /**
    * Get the base URL for Acestream links
    */

--- a/frontend/src/types/api-generated.ts
+++ b/frontend/src/types/api-generated.ts
@@ -331,6 +331,12 @@ export interface paths {
      */
     put: operations["update_epg_refresh_interval_api_v1_config_epg_refresh_interval_put"];
   };
+  "/api/v1/config/playback-routing": {
+    /** Get Playback Routing */
+    get: operations["get_playback_routing_api_v1_config_playback_routing_get"];
+    /** Update Playback Routing */
+    put: operations["update_playback_routing_api_v1_config_playback_routing_put"];
+  };
   "/api/v1/config/public_base_url": {
     /**
      * Get Public Base Url
@@ -2145,6 +2151,21 @@ export interface components {
        * @default 0
        */
       total?: number;
+    };
+    /** PlaybackRouting */
+    PlaybackRouting: {
+      /**
+       * Acexy Url
+       * @description HTTP(S) origin where the backend reaches Acexy in MPEG-TS mode
+       * @default http://localhost:8080
+       */
+      acexy_url?: string;
+      /**
+       * Use Acexy
+       * @description Route web, tuner and remote-player playback through Acexy
+       * @default false
+       */
+      use_acexy?: boolean;
     };
     /** PlayerCapabilities */
     PlayerCapabilities: {
@@ -4637,6 +4658,39 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["ConfigUpdateResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get Playback Routing */
+  get_playback_routing_api_v1_config_playback_routing_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PlaybackRouting"];
+        };
+      };
+    };
+  };
+  /** Update Playback Routing */
+  update_playback_routing_api_v1_config_playback_routing_put: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PlaybackRouting"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["PlaybackRouting"];
         };
       };
       /** @description Validation Error */

--- a/wiki/Remote-Players.md
+++ b/wiki/Remote-Players.md
@@ -8,6 +8,7 @@ You save each player once (name, VLC or Kodi, its address and password). After t
 
 - **Integrations › Remote players** lists every saved player with a live status line (Idle, or what it is playing and how far in), a play/pause button, a stop button and a volume slider.
 - **Send channel…** (under "More actions for" the player) opens a picker over your TV channels and Acestream streams; pick one and it starts on that player.
+- **Live TV › Send to player** lets you pick a saved player directly beside Watch, for both TV channels and unassigned streams. It sends the first listed source for a TV channel without opening the web player. To choose a different source, use the stream selector in the web player and its **Play on…** menu.
 - **Play on…** appears on every channel row and in the web player dialog, so you can push whatever you are looking at to a player without leaving the page.
 
 Nothing is installed on the player. The app talks to the web interface that VLC and Kodi already ship, and hands the player a normal stream link that it opens by itself. The video never passes through your browser.
@@ -138,3 +139,32 @@ That is a deliberate trade-off for a single-user app with no key management: tre
 
 - [Web Player](Web-Player.md) — play a channel in the browser instead
 - [Configuration Reference](Configuration.md#media-integrations) — `TUNER_ALLOWED_NETWORKS`, `PUBLIC_BASE_URL` and the rest
+
+## Playback routing
+
+In **Settings › Engine**, turn **Route playback through Acexy** on or off and
+save the **Acexy URL** reachable from the backend (default
+`http://localhost:8080`). Direct engine mode is the default. Acexy must already
+be running in MPEG-TS mode; this setting does not launch or reconfigure it.
+
+- **Acexy on:** web-player sessions and tuner relays read
+  `/ace/getstream?id=…` from Acexy without a PID. External players receive the
+  server relay URL so they follow the same route, even if a custom player link
+  format is saved. The public server address and tuner allowlist must therefore
+  allow those players to connect. Acexy owns multiplexing, PIDs and engine
+  cleanup; the app closes its stream connection when playback ends.
+- **Acexy off:** web-player sessions and tuner relay connections start the
+  configured engine directly with a fresh PID. External players use the server
+  relay or their saved link format. Direct HTTP AceStream links get a fresh PID
+  on each send, replacing fixed PIDs and the deprecated `sid` alias and filling
+  `{pid}` placeholders. Other URL options are preserved.
+
+The choice applies to new sessions; existing sessions, including shared browser
+sessions, keep their route until they end. Browser viewers of the same channel
+and audio track still share one HLS session. Engine health/status checks continue
+to use the engine URL, and copied links and exported playlists keep their own
+link-format settings. Acexy does not expose the engine's per-session peer
+statistics through this playback path.
+
+See the [Acexy usage documentation](https://github.com/Javinator9889/acexy#usage-)
+and the [AceStream playback API parameters](https://docs.acestream.net/developers/api-reference/).

--- a/wiki/Web-Player.md
+++ b/wiki/Web-Player.md
@@ -6,6 +6,10 @@ Play a channel straight in your browser — no VLC, no Acestream engine plugin, 
 
 Every image ships a small, statically-linked ffmpeg (built during the image build, one static binary per platform/flavor — no extra install step). When you press **Play**, the backend asks the AceStream engine for that channel and starts one ffmpeg process for it: the video track is copied through untouched, the audio track is re-encoded to AAC (AceStream channels are often MPEG-2 audio or AC-3, which browsers cannot play), and the result is repackaged as an HLS stream (2-second segments, a 6-segment sliding window) that `hls.js` (or the browser's native HLS support on Safari/iOS) plays back.
 
+Playback can connect directly to the engine (with a unique PID per session) or
+through Acexy. Choose **Route playback through Acexy** under **Settings › Engine**;
+see [Playback routing](Remote-Players.md#playback-routing).
+
 That segmenting and buffering means the player runs roughly 6–10 seconds behind live — expected for HLS, not a fault.
 
 One ffmpeg process is shared per channel and selected audio track: if two browser tabs (or two people) play the same channel with the same audio selection, they join the same session instead of doubling the transcode cost. A session is torn down automatically a few seconds after its last viewer leaves, or after it sits idle, so it does not keep using engine and CPU resources in the background.
@@ -25,6 +29,10 @@ Wherever a channel appears in the app — Acestream Channels, TV Channels (inclu
 While a channel is starting, the dialog shows the engine's peer count and download speed as they become available. Once segments are ready it switches to **Playing**. Closing the dialog (or navigating away) releases the session; if you are the only viewer, the backend stops ffmpeg and the engine stream a few seconds later.
 
 ## Live TV and choosing a stream
+
+**Send to player** beside Watch sends a channel directly to a saved external
+player without starting browser playback. Add players and access their playback
+controls under **Integrations › Remote players**.
 
 Open **Live TV** from navigation to browse active TV channels, search by name,
 category or channel number, and filter favorites. Each channel shows its current


### PR DESCRIPTION
## Scope

Playback now has a server-wide choice between direct AceStream sessions and Acexy, and Live TV can send a channel to an external player without first starting browser playback.

- Add **Settings → Engine → Route playback through Acexy** and a validated Acexy origin, persisted together through `GET/PUT /api/v1/config/playback-routing`.
- Direct mode remains the default. Web-player and tuner sessions use unique PIDs; direct HTTP links sent to external players now receive a fresh PID instead of stripping `{pid}` or reusing a fixed value.
- Acexy mode reads MPEG-TS without adding a PID or calling the engine JSON start/stat/stop API. External players use the server relay in this mode, bypassing saved custom link formats. Session ownership survives routing changes so cleanup does not stop a shared proxy stream.
- Add **Send to player** beside Watch for TV channels and unassigned streams, using the existing saved-player menu and feedback.
- Update OpenAPI/generated TypeScript contracts, focused tests, browser journeys and operator documentation. No database schema or container startup changes.

## Risks

- Acexy must already be running in MPEG-TS mode at the configured address. This setting does not enable or configure the sidecar.
- Remote players in Acexy mode need access to the public server relay and must pass the tuner network allowlist. Custom player link formats resume when Acexy routing is disabled.
- Existing sessions retain their route until teardown; shared browser sessions retain their existing behavior. Per-session engine peer statistics are unavailable through Acexy.
- Copied links and exported playlists keep their existing link-format settings.
- Operational rollback: disable Acexy routing for new sessions. Code rollback: revert this commit; no migration is required.

## Verification

Passed locally:

- Focused backend config, engine client, relay, remote-player, tuner network and failover suites: **122 passed**.
- Backend engine/relay/web-player/remote-player/failover lifecycle suites, including fake-ffmpeg process cleanup outside the sandbox: **97 passed** (overlaps the group above).
- Canonical quick backend contract/parity tests plus player, remote-player and tuner endpoint suites: **104 passed**.
- Focused Jest suites covering Live TV, player menus/dialogs, Settings, routing controls and the routing service: passed.
- `npm run typecheck` in frontend and e2e; `npm run lint -- --max-warnings=0` in frontend.
- `npm run test:mobile -- live-tv.spec.ts playback-routing.spec.ts`: **32 passed**, covering light/dark themes and phone, small-phone, tablet and desktop in Chromium, WebKit and Firefox. The suite builds the production frontend first.
- Runtime OpenAPI snapshot comparison and fresh generated-client comparison: matched.
- `bash scripts/ci/assert_no_legacy_paths.sh --strict` and `git diff --check`: passed.

Reviewed small-phone screenshots. Browser tests use mocked APIs and backend media tests use fake ffmpeg; live AceStream/Acexy playback and physical external players were not exercised. Jenkins validation remains to run on this PR; no release or publication was triggered manually.
