### PR TITLE
Verify stream signals and retain Overview job history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,3 +182,14 @@ process-group cleanup and intentional-stop behavior. The DB-independent
 `GET /api/v1/system/diagnostics` endpoint exports bounded fixed-file tails with
 credential masking and normal API-token enforcement, including during startup
 failure. Overview provides the download. See `docs/ops/runtime-diagnostics.md`.
+
+## Verified signal and scheduled job history
+
+Catalogue imports do not imply online status. Channel probes separate engine ID
+lookup (`network_status`) from media delivery (`is_online`); require identified A/V
+packets before claiming signal. Keep timeout/engine errors distinct from explicit
+ID-not-found responses. See `docs/ops/stream-check-pid.md`.
+
+Scheduled job launch times and outcomes persist in `scheduled_task_states`; restore
+after schema upgrade off the event loop and mark unfinished runs interrupted. Keep
+scalar results valid in the status API. See `docs/ops/scheduled-job-history.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,3 +223,14 @@ exit codes and supervisor cleanup when modifying capture. The authenticated
 `GET /api/v1/system/diagnostics` ZIP export is DB-independent and available during
 startup failures; Overview exposes the download. Keep file selection fixed, reads
 bounded and credential masking on export. See `docs/ops/runtime-diagnostics.md`.
+
+## Verified signal and scheduled job history
+
+Catalogue imports do not imply online status. Channel probes separate engine ID
+lookup (`network_status`) from media delivery (`is_online`); require identified A/V
+packets before claiming signal. Keep timeout/engine errors distinct from explicit
+ID-not-found responses. See `docs/ops/stream-check-pid.md`.
+
+Scheduled job launch times and outcomes persist in `scheduled_task_states`; restore
+after schema upgrade off the event loop and mark unfinished runs interrupted. Keep
+scalar results valid in the status API. See `docs/ops/scheduled-job-history.md`.

--- a/backend/app/api/endpoints/background_tasks.py
+++ b/backend/app/api/endpoints/background_tasks.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from app.models.background_task_status import BackgroundTaskStatus
 import logging
 
 from app.api.error_handlers import APIError
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 status_service = BackgroundTaskStatusService()
 
-@router.get("/background-tasks/status", tags=["background-tasks"])
+@router.get("/background-tasks/status", response_model=list[BackgroundTaskStatus], tags=["background-tasks"])
 def get_background_tasks_status():
     try:
         return [task.model_dump() for task in status_service.get_all_statuses()]

--- a/backend/app/api/endpoints/channels.py
+++ b/backend/app/api/endpoints/channels.py
@@ -2,6 +2,7 @@
 API endpoints for channel management
 """
 import logging
+from app.services.manual_job_service import run_manual_job
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
@@ -149,7 +150,7 @@ async def check_all_channels_status(
     else:
         # Check immediately for small numbers
         try:
-            results = await status_service.check_multiple_channels(channels, concurrency)
+            results = await run_manual_job("channel_status", status_service.check_multiple_channels, channels, concurrency)
         except Exception as exc:
             logger.error("Bulk status check failed channels=%s error=%s", len(channels), exc)
             raise APIError(
@@ -274,7 +275,7 @@ async def check_acestream_channel_status(acestreamchannel_id: str, db: Session =
         raise HTTPException(status_code=404, detail="Channel not found")
 
     status_service = ChannelStatusService(db)
-    result = await status_service.check_channel_status(channel)
+    result = await run_manual_job("channel_status", status_service.check_channel_status, channel)
     return result
 
 
@@ -351,7 +352,7 @@ async def _background_status_check(
     """Background task for checking channel statuses"""
     try:
         status_service = ChannelStatusService(db)
-        await status_service.check_multiple_channels(channels, concurrency)
+        await run_manual_job("channel_status", status_service.check_multiple_channels, channels, concurrency)
     except Exception as e:
         # Log error but do not re-raise from background task context.
         logger.error(

--- a/backend/app/api/endpoints/epg.py
+++ b/backend/app/api/endpoints/epg.py
@@ -2,6 +2,7 @@
 API endpoints for EPG management
 """
 import logging
+from app.services.manual_job_service import run_manual_job, refresh_epg_batch
 
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks, Response, Body
 from sqlalchemy.orm import Session
@@ -113,7 +114,7 @@ def refresh_epg_source(
         raise HTTPException(status_code=404, detail="EPG source not found")
 
     try:
-        background_tasks.add_task(epg_service.refresh_source, source_id)
+        background_tasks.add_task(run_manual_job, "epg_refresh", epg_service.refresh_source, source_id)
     except Exception as exc:
         logger.error("Failed to enqueue EPG refresh source_id=%s error=%s", source_id, exc)
         raise APIError(
@@ -143,9 +144,11 @@ def refresh_all_epg_sources(
     sources = epg_service.get_enabled_sources()
 
     results = []
+    if sources:
+        background_tasks.add_task(run_manual_job, "epg_refresh", refresh_epg_batch, epg_service,
+                                  [source.id for source in sources])
     for source in sources:
         try:
-            background_tasks.add_task(epg_service.refresh_source, source.id)
             results.append({
                 "source_id": source.id,
                 "message": f"EPG refresh started for source: {source.name}",

--- a/backend/app/api/endpoints/scrapers.py
+++ b/backend/app/api/endpoints/scrapers.py
@@ -10,6 +10,7 @@ from app.api.dependencies import get_scraper_service
 from app.api.error_handlers import APIError
 from app.schemas.scraper import ScraperRequest, ScraperResult, URLResponse, URLCreate, URLUpdate
 from app.services.scraper_service import ScraperService
+from app.services.manual_job_service import run_manual_job, scrape_batch
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ async def scrape_url(
         if request.run_async:
             # Run in background
             background_tasks.add_task(
-                scraper_service.scrape_url,
+                run_manual_job, "url_scraping", scraper_service.scrape_url,
                 request.url,
                 request.url_type
             )
@@ -54,7 +55,7 @@ async def scrape_url(
             )
         else:
             # Run synchronously
-            channels, status_msg = await scraper_service.scrape_url(request.url, request.url_type)
+            channels, status_msg = await run_manual_job("url_scraping", scraper_service.scrape_url, request.url, request.url_type)
 
             return ScraperResultExtended(
                 message="Scraping completed successfully" if status_msg == "OK" else status_msg,
@@ -163,7 +164,7 @@ async def scrape_specific_url(
     if url_entity and not url_entity.enabled:
         raise HTTPException(status_code=400, detail="URL is disabled")
     background_tasks.add_task(
-        scraper_service.scrape_url,
+        run_manual_job, "url_scraping", scraper_service.scrape_url,
         url.url,
         url.url_type
     )
@@ -189,12 +190,10 @@ async def scrape_all_urls(
     if limit is not None:
         urls = urls[:limit]
     results = []
+    if urls:
+        background_tasks.add_task(run_manual_job, "url_scraping", scrape_batch, scraper_service,
+                                  [(url.url, url.url_type) for url in urls])
     for url in urls:
-        background_tasks.add_task(
-            scraper_service.scrape_url,
-            url.url,
-            url.url_type
-        )
         results.append(ScraperResultExtended(
             message="Scraping started in background",
             channels=[],

--- a/backend/app/models/background_task_status.py
+++ b/backend/app/models/background_task_status.py
@@ -8,5 +8,5 @@ class BackgroundTaskStatus(BaseModel):
     next_run: Optional[datetime]
     status: str  # e.g. 'idle', 'running', 'error'
     last_error: Optional[str]
-    last_result: Optional[Dict[str, Any]]
+    last_result: Optional[Any]
     progress: Optional[Dict[str, Any]] = None  # e.g. {"processed": 1200, "total": 30000, "percent": 4.0}

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -112,6 +112,7 @@ class AcestreamChannel(Base):
     last_seen = Column(UtcDateTime(), default=_utcnow)
     is_active = Column(Boolean, default=True)
     is_online = Column(Boolean, nullable=True)
+    network_status = Column(String(16), nullable=True)
     last_checked = Column(UtcDateTime(), nullable=True)
     check_error = Column(Text, nullable=True)
     audio_tracks = Column(JSON, nullable=True)
@@ -348,3 +349,13 @@ class DashboardConfig(Base):
     retention_days = Column(Integer, nullable=False, server_default='7')
     auto_refresh_interval = Column(Integer, nullable=False, server_default='60')  # seconds
     # Add more config fields as needed
+
+
+class ScheduledTaskState(Base):
+    """Latest scheduler run, retained across application restarts."""
+    __tablename__ = "scheduled_task_states"
+    task_name = Column(String(128), primary_key=True)
+    last_run = Column(UtcDateTime(), nullable=True)
+    status = Column(String(32), nullable=False)
+    last_error = Column(Text, nullable=True)
+    last_result = Column(JSON, nullable=True)

--- a/backend/app/repositories/channel_repository.py
+++ b/backend/app/repositories/channel_repository.py
@@ -274,7 +274,7 @@ class ChannelRepository:
                 tv_channel_id=tv_channel_id,
                 last_seen=datetime.now(timezone.utc),
                 is_active=True,
-                is_online=is_online if is_online is not None else True  # Default to True
+                is_online=is_online
             )
             self.db.add(channel)
         else:
@@ -385,18 +385,19 @@ class ChannelRepository:
         ).scalar()
 
     def get_status_snapshot(self, channel_id: str) -> Optional[dict]:
-        row = self.db.query(AcestreamChannel.is_online, AcestreamChannel.last_checked).filter(
+        row = self.db.query(AcestreamChannel.is_online, AcestreamChannel.last_checked, AcestreamChannel.network_status).filter(
             AcestreamChannel.id == channel_id,
         ).first()
         return dict(row._mapping) if row else None
 
-    def update_channel_status(self, channel_id: str, is_online: bool, error: str = None, *, bitrate_bps: Optional[int] = None, audio_tracks: Optional[list] = None) -> AcestreamChannel:
+    def update_channel_status(self, channel_id: str, is_online: bool, error: str = None, *, bitrate_bps: Optional[int] = None, audio_tracks: Optional[list] = None, network_status: str = "unknown") -> AcestreamChannel:
         """Update the online status of a channel"""
         channel = self.get_channel_by_id(channel_id)
         if not channel:
             return None
 
         channel.is_online = is_online
+        channel.network_status = network_status
         channel.last_checked = datetime.now(timezone.utc)
         channel.check_error = error
         if audio_tracks is not None:

--- a/backend/app/repositories/task_state_repository.py
+++ b/backend/app/repositories/task_state_repository.py
@@ -1,0 +1,23 @@
+"""Bounded latest-run storage: one row per scheduled task, no runtime objects."""
+from app.config.database import SessionLocal
+from app.models.models import ScheduledTaskState
+
+
+class TaskStateRepository:
+    def load(self):
+        with SessionLocal() as db:
+            return {row.task_name: {
+                'task_name': row.task_name, 'last_run': row.last_run,
+                'status': row.status, 'last_error': row.last_error,
+                'last_result': row.last_result, 'next_run': None, 'progress': None,
+            } for row in db.query(ScheduledTaskState).all()}
+
+    def save(self, state):
+        with SessionLocal() as db:
+            row = db.get(ScheduledTaskState, state['task_name'])
+            if row is None:
+                row = ScheduledTaskState(task_name=state['task_name'])
+                db.add(row)
+            for key in ('last_run', 'status', 'last_error', 'last_result'):
+                setattr(row, key, state.get(key))
+            db.commit()

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -23,7 +23,7 @@ class AcestreamChannelCreate(AcestreamChannelBase):
     logo: Optional[str] = None
     tvg_id: Optional[str] = None
     tvg_name: Optional[str] = None
-    is_online: Optional[bool] = True  # Default to True
+    is_online: Optional[bool] = None
 
 
 
@@ -52,6 +52,7 @@ class AcestreamChannelResponse(AcestreamChannelBase):
     last_seen: datetime
     is_active: bool
     is_online: Optional[bool] = None
+    network_status: Optional[Literal["found", "not_found", "unknown"]] = Field(None, description="Last engine ID lookup: found, explicitly not found, or inconclusive; not proof of permanent network existence")
     last_checked: Optional[datetime] = None
     check_error: Optional[str] = None
     audio_tracks: Optional[List[AudioTrack]] = Field(None, description="Audio tracks found at the last successful media probe; null means unknown")

--- a/backend/app/schemas/channel_status.py
+++ b/backend/app/schemas/channel_status.py
@@ -2,13 +2,14 @@
 Schemas for channel status operations
 """
 from datetime import datetime
-from typing import Optional, List
+from typing import Optional, List, Literal
 from pydantic import BaseModel, ConfigDict
 
 
 class ChannelStatusResponse(BaseModel):
     """Response schema for channel status check"""
     channel_id: str
+    network_status: Optional[Literal["found", "not_found", "unknown"]] = None
     is_online: bool
     status: str  # 'online', 'offline', 'error', 'skipped' (in use; previous status retained)
     message: str

--- a/backend/app/services/channel_status_service.py
+++ b/backend/app/services/channel_status_service.py
@@ -116,8 +116,11 @@ class ChannelStatusService:
                     # and catalogue status cannot prove current emission.
                     if (previous_downloaded is not None and downloaded > previous_downloaded
                             and state.get('status') in ('dl', 'prebuf', 'buf')):
-                        media = None if self._in_use(channel_id) else await probe_media(engine_url, response.get('playback_url'))
-                        return True, 'Broadcast data is arriving', media
+                        playback_url = self._session_url(engine_url, response.get('playback_url'), 'r')
+                        media = None if self._in_use(channel_id) else await probe_media(engine_url, playback_url)
+                        if media and media.get('signal_verified') is True:
+                            return True, 'Media signal verified', media
+                        return False, 'ID found, but no media signal verified before timeout', media
                     previous_downloaded = downloaded
                 await asyncio.sleep(min(1.0, max(0, deadline - asyncio.get_running_loop().time())))
         finally:
@@ -141,6 +144,7 @@ class ChannelStatusService:
     def _skipped_result(channel: AcestreamChannel) -> Dict[str, Any]:
         return {
             'channel_id': channel.id, 'is_online': channel.is_online is True,
+            'network_status': channel.network_status,
             'status': 'skipped', 'message': 'Source is in use; keeping its previous status',
             'last_checked': channel.last_checked or datetime.now(timezone.utc), 'error': None,
         }
@@ -154,6 +158,7 @@ class ChannelStatusService:
             return None
         return {
             'channel_id': channel_id, 'is_online': snapshot['is_online'] is True,
+            'network_status': snapshot.get('network_status'),
             'status': 'skipped', 'message': 'Recently checked; using the latest channel status',
             'last_checked': snapshot['last_checked'], 'error': None,
         }
@@ -218,6 +223,7 @@ class ChannelStatusService:
         online = False
         media = None
         engine_url = None
+        network_status = 'unknown'
         try:
             engine_url = self._get_engine_url()
             if not await self._wait_for_engine(engine_url):
@@ -236,12 +242,22 @@ class ChannelStatusService:
                 if self._in_use(channel.id):
                     return self._skipped_result(channel)
                 http_status, data, parse_error = await self._fetch_engine_response(status_url, params, timeout * 2)
+            if isinstance(data, dict):
+                error_text = str(data.get('error') or '').strip().lower()
+                if error_text in {'not found', 'content not found', 'content id not found', 'unknown content id'}:
+                    network_status = 'not_found'
+                elif not data.get('error') and isinstance(data.get('response'), dict):
+                    response = data['response']
+                    if self._session_url(engine_url, response.get('stat_url'), 'stat') and self._session_url(engine_url, response.get('command_url'), 'cmd'):
+                        network_status = 'found'
             if http_status != 200:
                 message = f'HTTP {http_status}'
             elif parse_error or not isinstance(data, dict):
                 message = 'Invalid response format'
             else:
                 online, message, media = await self._verify_broadcast(engine_url, data, timeout, channel.id)
+                if network_status == 'not_found':
+                    message = 'Engine reports this content ID was not found'
         except asyncio.TimeoutError:
             message = 'Request timeout'
         except Exception:
@@ -255,9 +271,10 @@ class ChannelStatusService:
         error = None if online else message
         if persist:
             self.channel_repository.update_channel_status(channel.id, online, error, bitrate_bps=media.get("bitrate_bps") if media else None,
-                audio_tracks=media.get("audio_tracks") if media else None)
+                audio_tracks=media.get("audio_tracks") if media else None, network_status=network_status)
         return {
             'channel_id': channel.id,
+            'network_status': network_status,
             'is_online': online,
             'status': 'online' if online else 'offline',
             'message': message,

--- a/backend/app/services/manual_job_service.py
+++ b/backend/app/services/manual_job_service.py
@@ -1,0 +1,57 @@
+"""Track interactive jobs without replacing their scheduled counterparts."""
+import asyncio
+import inspect
+from datetime import datetime, timezone
+from starlette.concurrency import run_in_threadpool
+from app.services.task_service import task_service
+
+
+def _summary(kind, result):
+    if kind == 'url_scraping':
+        rows = result if isinstance(result, list) else [result]
+        return {'processed': len(rows), 'failures': sum(str(status).lower().startswith('error') for _, status in rows),
+                'channels': sum(len(channels) for channels, _ in rows)}
+    if kind == 'epg_refresh':
+        rows = result if isinstance(result, list) else [result]
+        successful = sum(bool(row.get('success')) for row in rows)
+        return {'sources': len(rows), 'successful': successful, 'failed': len(rows) - successful}
+    rows = result if isinstance(result, list) else [result]
+    return {'checked': sum(row['status'] != 'skipped' for row in rows),
+            'skipped': sum(row['status'] == 'skipped' for row in rows),
+            'online': sum(row['status'] != 'skipped' and row['is_online'] for row in rows)}
+
+
+async def run_manual_job(kind, func, *args):
+    """Retain the latest-started manual run per family, even if calls overlap."""
+    job_id = f'manual_{kind}'
+    state = {'task_name': job_id, 'last_run': datetime.now(timezone.utc),
+             'next_run': None, 'status': 'running', 'last_error': None,
+             'last_result': None, 'progress': None}
+    await asyncio.to_thread(task_service.set_manual_state, job_id, state)
+    await asyncio.to_thread(task_service.persist_current_state, job_id, state)
+    try:
+        if inspect.iscoroutinefunction(func):
+            result = await func(*args)
+        else:
+            result = await run_in_threadpool(func, *args)
+        state['last_result'] = _summary(kind, result)
+        state['status'] = 'idle'
+        return result
+    except asyncio.CancelledError:
+        state['status'] = 'interrupted'
+        state['last_error'] = 'Manual run was interrupted'
+        raise
+    except Exception:
+        state['status'] = 'error'
+        state['last_error'] = 'Manual run failed; see application logs for details'
+        raise
+    finally:
+        await asyncio.to_thread(task_service.persist_current_state, job_id, state)
+
+
+async def scrape_batch(service, urls):
+    return [await service.scrape_url(url, url_type) for url, url_type in urls]
+
+
+def refresh_epg_batch(service, source_ids):
+    return [service.refresh_source(source_id) for source_id in source_ids]

--- a/backend/app/services/scraper_service.py
+++ b/backend/app/services/scraper_service.py
@@ -83,7 +83,8 @@ class ScraperService:
                     # association into the INSERT; existing rows are assigned
                     # by the repository's conflict-checked UPDATE above.
                     tv_channel_id=metadata.get('tv_channel_id'),
-                    is_online=True,
+                    # Catalogue presence is not evidence of a live signal.
+                    is_online=None,
                     commit=False,
                 )
                 persisted_channels.append(persisted)

--- a/backend/app/services/stream_bitrate_service.py
+++ b/backend/app/services/stream_bitrate_service.py
@@ -40,6 +40,20 @@ def sample_bitrate(payload: dict) -> int | None:
     return rate if 0 < rate <= 1_000_000_000 else None
 
 
+def has_media_packets(payload: dict) -> bool:
+    """Stream declarations alone are insufficient: require encoded A/V packets."""
+    indexes = {stream.get("index") for stream in payload.get("streams", [])
+               if stream.get("codec_type") in ("video", "audio") and stream.get("codec_name")
+               and isinstance(stream.get("index"), int)}
+    for packet in payload.get("packets", []):
+        try:
+            if packet.get("stream_index") in indexes and int(packet.get("size", 0)) > 0:
+                return True
+        except (TypeError, ValueError):
+            continue
+    return False
+
+
 async def probe_media(engine_url: str, playback_url: object) -> dict | None:
     configured = get_settings().FFMPEG_BINARY_PATH
     sibling = Path(configured).with_name("ffprobe") if configured else None
@@ -76,7 +90,7 @@ async def probe_media(engine_url: str, playback_url: object) -> dict | None:
                     return None
             process = await asyncio.create_subprocess_exec(
                 binary, "-v", "error", "-protocol_whitelist", "pipe", "-f", "mpegts",
-                "-show_entries", "format=bit_rate:packet=pts_time,size:stream=codec_type,codec_name,channels,channel_layout:stream_tags=language,title", "-of", "json", "-i", "pipe:0",
+                "-show_entries", "format=bit_rate:packet=stream_index,pts_time,size:stream=index,codec_type,codec_name,channels,channel_layout:stream_tags=language,title", "-of", "json", "-i", "pipe:0",
                 stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
             )
             stdout, _ = await process.communicate(bytes(sample))
@@ -84,7 +98,7 @@ async def probe_media(engine_url: str, playback_url: object) -> dict | None:
                 return None
             payload = json.loads(stdout)
             audio = [stream for stream in payload.get("streams", []) if stream.get("codec_type") == "audio"]
-            return {"bitrate_bps": sample_bitrate(payload), "audio_tracks": [
+            return {"signal_verified": has_media_packets(payload), "bitrate_bps": sample_bitrate(payload), "audio_tracks": [
                 {"index": index, "codec": stream.get("codec_name"), "channels": stream.get("channels"),
                  "channel_layout": stream.get("channel_layout"),
                  "language": stream.get("tags", {}).get("language"), "title": stream.get("tags", {}).get("title")}

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -15,7 +15,8 @@ import logging
 
 
 class TaskService:
-    def __init__(self):
+    def __init__(self, state_store=None):
+        self._state_store = state_store
         self.scheduler = self._new_scheduler()
         self.shutdown_event = Event()
         self.logger = logging.getLogger("TaskService")
@@ -42,6 +43,30 @@ class TaskService:
             if interval_seconds:
                 state["next_run"] = datetime.now(timezone.utc) + timedelta(seconds=interval_seconds)
             return state
+
+    def restore_states(self):
+        """Called after schema upgrade, off the application event loop."""
+        if self._state_store is None:
+            return
+        try:
+            states = self._state_store.load()
+            for state in states.values():
+                if state["status"] == "running":
+                    state["status"] = "interrupted"
+                    state["last_error"] = "Application stopped before this run completed"
+                    self._state_store.save(state)
+            with self._state_lock:
+                self._task_states = states
+        except Exception:
+            self.logger.exception("Could not restore scheduled task history")
+
+    def _persist_state(self, state):
+        if self._state_store is not None:
+            try:
+                self._state_store.save(dict(state))
+            except Exception:
+                # History failure must not turn successful maintenance into failure.
+                self.logger.exception("Could not save scheduled task history task=%s", state["task_name"])
 
     def start(self):
         if self.scheduler.running:
@@ -85,9 +110,11 @@ class TaskService:
             state = self._ensure_task_state(job_id)
             with self._state_lock:
                 state["status"] = "running"
+                state["last_run"] = datetime.now(timezone.utc)
                 state["last_error"] = None
                 state["last_result"] = None
                 state["progress"] = None
+            self.persist_current_state(job_id, state)
             try:
                 result = func(*args, **kwargs)
                 if asyncio.iscoroutine(result):
@@ -98,9 +125,9 @@ class TaskService:
                     next_run = job.next_run_time
                 with self._state_lock:
                     state["status"] = "idle"
-                    state["last_run"] = datetime.now(timezone.utc)
                     state["next_run"] = next_run
                     state["last_result"] = result
+                self.persist_current_state(job_id, state)
                 return result
             except Exception as exc:
                 next_run = None
@@ -109,10 +136,10 @@ class TaskService:
                     next_run = job.next_run_time
                 with self._state_lock:
                     state["status"] = "error"
-                    state["last_run"] = datetime.now(timezone.utc)
                     state["next_run"] = next_run
                     state["last_error"] = str(exc)
                     state["last_result"] = None
+                self.persist_current_state(job_id, state)
                 self.logger.exception("Scheduled task failed task=%s error=%s", job_id, exc)
                 raise
 
@@ -203,6 +230,16 @@ class TaskService:
         except JobLookupError:
             self.logger.warning(f"Tried to remove non-existent task '{job_id}'.")
 
+    def set_manual_state(self, job_id, state):
+        with self._state_lock:
+            self._task_states[job_id] = state
+
+    def persist_current_state(self, job_id, state):
+        # An older overlapping manual run must not overwrite the latest run.
+        with self._state_lock:
+            if self._task_states.get(job_id) is state:
+                self._persist_state(state)
+
     def get_jobs(self):
         return self.scheduler.get_jobs()
 
@@ -215,4 +252,6 @@ class TaskService:
         with self._state_lock:
             return {job_id: dict(state) for job_id, state in self._task_states.items()}
 
-task_service = TaskService()
+from app.repositories.task_state_repository import TaskStateRepository
+
+task_service = TaskService(state_store=TaskStateRepository())

--- a/backend/main.py
+++ b/backend/main.py
@@ -219,6 +219,7 @@ async def lifespan(app: FastAPI):
             database_phase = False
             startup_service.record('Starting background services')
             services_started = True
+            await asyncio.to_thread(task_service.restore_states)
             task_service.start()
             task_service.add_interval_task(run_activity_log_cleanup, seconds=86400, job_id="activity_log_cleanup")  # daily
             scrape_hours, epg_hours, status_minutes = await asyncio.to_thread(_configured_intervals)

--- a/backend/migrations/versions/20260907_1500_signal_and_task_state.py
+++ b/backend/migrations/versions/20260907_1500_signal_and_task_state.py
@@ -1,0 +1,26 @@
+"""Separate ID lookup from signal verification and retain scheduler outcomes."""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20260907_1500'
+down_revision = '20260906_1300'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('acestream_channels', sa.Column('network_status', sa.String(16), nullable=True))
+    # Old positives include catalogue imports and P2P counters, not verified media.
+    op.execute('UPDATE acestream_channels SET is_online = NULL, last_checked = NULL, check_error = NULL')
+    op.create_table('scheduled_task_states',
+        sa.Column('task_name', sa.String(128), primary_key=True),
+        sa.Column('last_run', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('status', sa.String(32), nullable=False),
+        sa.Column('last_error', sa.Text(), nullable=True),
+        sa.Column('last_result', sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_table('scheduled_task_states')
+    with op.batch_alter_table('acestream_channels') as batch:
+        batch.drop_column('network_status')

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -44,7 +44,6 @@
                 "type": "null"
               }
             ],
-            "default": true,
             "title": "Is Online"
           },
           "logo": {
@@ -255,6 +254,23 @@
             "minLength": 1,
             "title": "Name",
             "type": "string"
+          },
+          "network_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "found",
+                  "not_found",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last engine ID lookup: found, explicitly not found, or inconclusive; not proof of permanent network existence",
+            "title": "Network Status"
           },
           "source_url": {
             "anyOf": [
@@ -924,6 +940,84 @@
         "title": "AudioTrack",
         "type": "object"
       },
+      "BackgroundTaskStatus": {
+        "properties": {
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
+          "last_result": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Result"
+          },
+          "last_run": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Run"
+          },
+          "next_run": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Run"
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Progress"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "task_name": {
+            "title": "Task Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "task_name",
+          "last_run",
+          "next_run",
+          "status",
+          "last_error",
+          "last_result"
+        ],
+        "title": "BackgroundTaskStatus",
+        "type": "object"
+      },
       "BaseUrlCreate": {
         "properties": {
           "is_default": {
@@ -1172,6 +1266,22 @@
           "message": {
             "title": "Message",
             "type": "string"
+          },
+          "network_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "found",
+                  "not_found",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Network Status"
           },
           "status": {
             "title": "Status",
@@ -7529,7 +7639,13 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/BackgroundTaskStatus"
+                  },
+                  "title": "Response Get Background Tasks Status Api V1 Background Tasks Status Get",
+                  "type": "array"
+                }
               }
             },
             "description": "Successful Response"

--- a/backend/tests/test_channel_broadcast_probe.py
+++ b/backend/tests/test_channel_broadcast_probe.py
@@ -26,6 +26,7 @@ def probe(db_session):
 def session_response():
     return {'response': {
         'is_live': 1,
+        'playback_url': 'http://127.0.0.1:6878/ace/r/hash/session',
         'stat_url': 'http://127.0.0.1:6878/ace/stat/hash/session',
         'command_url': 'http://127.0.0.1:6878/ace/cmd/hash/session',
     }, 'error': None}
@@ -47,8 +48,10 @@ async def test_metadata_and_errors_do_not_mean_online(probe, payload):
 
 
 @pytest.mark.asyncio
-async def test_only_increasing_downloads_confirm_broadcast_and_stop_session(probe, monkeypatch):
+async def test_media_packets_confirm_broadcast_and_stop_session(probe, monkeypatch):
     monkeypatch.setattr('app.services.channel_status_service.asyncio.sleep', AsyncMock())
+    media_probe = AsyncMock(return_value={'signal_verified': True})
+    monkeypatch.setattr('app.services.channel_status_service.probe_media', media_probe)
     probe._fetch_engine_response = AsyncMock(side_effect=[
         (200, session_response(), None),
         (200, {'response': {'status': 'dl', 'downloaded': 100}}, None),
@@ -57,6 +60,8 @@ async def test_only_increasing_downloads_confirm_broadcast_and_stop_session(prob
     ])
     result = await probe.check_channel_status(AcestreamChannel(id='a' * 40, name='Example'), identifier='infohash', persist=False)
     assert result['is_online'] is True
+    assert result['network_status'] == 'found'
+    media_probe.assert_awaited_once_with('http://engine.test:6878', 'http://engine.test:6878/ace/r/hash/session')
     calls = probe._fetch_engine_response.call_args_list
     assert calls[0].args[1]['infohash'] == 'a' * 40
     assert 'method' not in calls[0].args[1]
@@ -115,9 +120,9 @@ async def test_probe_player_ids_are_unique_between_service_instances(db_session)
 
 
 @pytest.mark.asyncio
-async def test_online_check_persists_measured_media_but_probe_failure_stays_online(probe, monkeypatch):
+async def test_downloads_without_verified_media_are_not_online(probe, monkeypatch):
     monkeypatch.setattr('app.services.channel_status_service.asyncio.sleep', AsyncMock())
-    for metadata in [None, {'bitrate_bps': 8_000_000, 'audio_tracks': [{'index': 0, 'language': 'spa'}]}]:
+    for metadata in [None, {'signal_verified': False, 'bitrate_bps': None, 'audio_tracks': []}, {'signal_verified': True, 'bitrate_bps': 8_000_000, 'audio_tracks': [{'index': 0, 'language': 'spa'}]}]:
         monkeypatch.setattr('app.services.channel_status_service.probe_media', AsyncMock(return_value=metadata))
         probe._fetch_engine_response = AsyncMock(side_effect=[
             (200, session_response(), None),
@@ -126,7 +131,8 @@ async def test_online_check_persists_measured_media_but_probe_failure_stays_onli
             (200, {'response': 'ok'}, None),
         ])
         result = await probe.check_channel_status(AcestreamChannel(id='a' * 40, name='Example'))
-        assert result['is_online'] is True
+        assert result['is_online'] is bool(metadata and metadata['signal_verified'])
+        assert result['network_status'] == 'found'
         assert probe.channel_repository.update_channel_status.call_args.kwargs['bitrate_bps'] == (metadata['bitrate_bps'] if metadata else None)
         assert probe.channel_repository.update_channel_status.call_args.kwargs['audio_tracks'] == (metadata['audio_tracks'] if metadata else None)
 
@@ -260,3 +266,30 @@ def test_bulk_status_counts_exclude_skipped_probes(client, db_session, monkeypat
     assert result.json()['offline_count'] == 0
     assert result.json()['total_checked'] == 0
     assert '1 skipped' in result.json()['message']
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('http_status,payload,expected', [
+    (200, {'error': 'not found'}, 'not_found'),
+    (200, {'error': 'content not found'}, 'not_found'),
+    (200, {'error': 'no peers'}, 'unknown'),
+    (404, None, 'unknown'),  # an absent API route is not an absent content ID
+    (500, None, 'unknown'),
+])
+async def test_lookup_failure_is_separate_from_signal(probe, http_status, payload, expected):
+    probe._fetch_engine_response = AsyncMock(return_value=(http_status, payload, None))
+    result = await probe.check_channel_status(AcestreamChannel(id='f' * 40, name='Example'))
+    assert result['network_status'] == expected
+    assert result['is_online'] is False
+    assert probe.channel_repository.update_channel_status.call_args.kwargs['network_status'] == expected
+
+
+def test_catalogue_upsert_does_not_claim_or_overwrite_signal(db_session):
+    from app.repositories.channel_repository import ChannelRepository
+    repo = ChannelRepository(db_session)
+    channel = repo.create_or_update_channel(channel_id='f' * 40, name='Example')
+    assert channel.is_online is None
+    repo.update_channel_status(channel.id, False, 'No signal', network_status='found')
+    channel = repo.create_or_update_channel(channel_id=channel.id, name='Listed again')
+    assert channel.is_online is False
+    assert channel.network_status == 'found'

--- a/backend/tests/test_schema_parity.py
+++ b/backend/tests/test_schema_parity.py
@@ -102,6 +102,7 @@ def test_acestream_channels_schema_includes_runtime_last_seen(tmp_path):
             'last_seen',
             'is_active',
             'is_online',
+            'network_status',
             'last_checked',
             'check_error',
             'bitrate_bps',

--- a/backend/tests/test_stream_bitrate.py
+++ b/backend/tests/test_stream_bitrate.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from app.services.stream_bitrate_service import sample_bitrate, probe_media
+from app.services.stream_bitrate_service import sample_bitrate, probe_media, has_media_packets
 
 
 @pytest.mark.parametrize('value', ['N/A', None, -1, 0, 'nan', 'inf'])
@@ -81,3 +81,29 @@ async def test_probe_rejects_redirect_before_contacting_other_host(monkeypatch):
         lambda **kwargs: factory(transport=httpx.MockTransport(handler), **kwargs))
     assert await probe_media('http://engine', 'http://engine/media') is None
     assert requested == ['engine']
+
+
+@pytest.mark.parametrize('packets,expected', [
+    ([], False),
+    ([{'stream_index': 0, 'size': '0'}], False),
+    ([{'stream_index': 1, 'size': '123'}], False),
+    ([{'stream_index': 0, 'size': '123'}], True),
+    ([{'stream_index': 0, 'size': 'invalid'}], False),
+])
+def test_signal_requires_packets_from_identified_media_stream(packets, expected):
+    assert has_media_packets({'streams': [{'index': 0, 'codec_type': 'video', 'codec_name': 'h264'}], 'packets': packets}) is expected
+
+
+def test_signal_and_history_migration_resets_unverified_status(tmp_path):
+    from sqlalchemy import create_engine, inspect, text
+    from migration_test_utils import upgrade_to_revision, database_url_for, upgrade_to_head
+    path = tmp_path / 'signal.db'
+    upgrade_to_revision(path, '20260906_1300')
+    engine = create_engine(database_url_for(path))
+    with engine.begin() as conn:
+        conn.execute(text("INSERT INTO acestream_channels (id, name, is_online, bitrate_bps) VALUES ('existing', 'Existing', 1, 8000000)"))
+    upgrade_to_head(path)
+    with engine.connect() as conn:
+        assert conn.execute(text('SELECT name, is_online, network_status, bitrate_bps FROM acestream_channels')).one() == ('Existing', None, None, 8000000)
+    assert 'scheduled_task_states' in inspect(engine).get_table_names()
+    engine.dispose()

--- a/backend/tests/test_task_service.py
+++ b/backend/tests/test_task_service.py
@@ -102,3 +102,81 @@ def test_task_progress_is_reported_while_running():
 
     assert state["progress"] == {"percent": 42.0, "processed": 42, "total": 100}
     assert service.get_task_states()["progress_job"]["progress"]["percent"] == 42.0
+
+
+def test_run_start_outcome_and_interruption_survive_new_service(alembic_backend_runtime):
+    from app.repositories.task_state_repository import TaskStateRepository
+    from app.models.background_task_status import BackgroundTaskStatus
+    store = TaskStateRepository()
+    service = TaskService(state_store=store)
+    observed = {}
+
+    def cleanup():
+        during = store.load()['activity_log_cleanup']
+        assert during['status'] == 'running'
+        assert during['last_run'] is not None
+        observed['started'] = during['last_run']
+        return 3  # real cleanup result is a scalar, not a dictionary
+
+    service._instrument_task('activity_log_cleanup', cleanup)()
+    restored = TaskService(state_store=store)
+    restored.restore_states()
+    state = restored.get_task_state('activity_log_cleanup')
+    assert state['last_run'] == observed['started']
+    assert state['last_result'] == 3
+    assert BackgroundTaskStatus(**state).last_result == 3
+    store.save({**state, 'status': 'running'})
+    restored.restore_states()
+    interrupted = restored.get_task_state('activity_log_cleanup')
+    assert interrupted['status'] == 'interrupted'
+    assert 'before this run completed' in interrupted['last_error']
+
+
+def test_failed_run_survives_restart(alembic_backend_runtime):
+    import pytest
+    from app.repositories.task_state_repository import TaskStateRepository
+    store = TaskStateRepository()
+    service = TaskService(state_store=store)
+    def fail():
+        raise ValueError('test failure')
+    with pytest.raises(ValueError):
+        service._instrument_task('epg_refresh', fail)()
+    restored = TaskService(state_store=store)
+    restored.restore_states()
+    assert restored.get_task_state('epg_refresh')['last_error'] == 'test failure'
+    assert restored.get_task_state('epg_refresh')['status'] == 'error'
+
+
+async def _manual_overlap_scenario(monkeypatch):
+    import asyncio
+    from app.services import manual_job_service
+    service = TaskService()
+    monkeypatch.setattr(manual_job_service, 'task_service', service)
+    began = asyncio.Event()
+    finish = asyncio.Event()
+    async def old_scrape():
+        began.set()
+        await finish.wait()
+        return [], 'Error: older request failed'
+    first = asyncio.create_task(manual_job_service.run_manual_job('url_scraping', old_scrape))
+    await began.wait()
+    async def new_scrape():
+        return [1, 2], 'OK'
+    await manual_job_service.run_manual_job('url_scraping', new_scrape)
+    finish.set()
+    await first
+    state = service.get_task_state('manual_url_scraping')
+    assert state['status'] == 'idle'
+    assert state['last_result'] == {'processed': 1, 'failures': 0, 'channels': 2}
+    assert state['next_run'] is None
+
+
+def test_overlapping_manual_runs_keep_latest_started_outcome(monkeypatch):
+    import asyncio
+    asyncio.run(_manual_overlap_scenario(monkeypatch))
+
+
+def test_manual_bulk_summaries():
+    from app.services.manual_job_service import _summary
+    assert _summary('epg_refresh', [{'success': True}, {'success': False}]) == {'sources': 2, 'successful': 1, 'failed': 1}
+    assert _summary('url_scraping', [([], 'OK'), ([], 'Error: fetch failed')])['failures'] == 1

--- a/docs/ops/scheduled-job-history.md
+++ b/docs/ops/scheduled-job-history.md
@@ -1,0 +1,22 @@
+# Scheduled job history
+
+Overview displays the most recent scheduler run's launch time, result, and next
+scheduled time. The latest run per task is stored in `scheduled_task_states`, so
+application/container restarts retain history when the database is persisted.
+
+The launch time is recorded before the task starts work. Running tasks show
+“In progress”; completion shows the returned summary (including scalar cleanup
+counts), and exceptions show the failure. If the application stops before a run
+records completion, the next startup labels that run “Interrupted”. Next-run times
+come from the current scheduler, not the saved history. A run that has never happened
+shows “Not run yet”; old in-memory history from before this change cannot be recovered.
+
+History loading occurs after Alembic upgrades in a worker thread. Storage errors
+are logged without turning successful maintenance into a failed task. Only the
+latest outcome is retained per scheduler job; this is not an unbounded execution log.
+
+Interactive scrapes, EPG refreshes, and channel checks appear as separate “manual”
+rows, with no next-run time. Bulk actions record an aggregate result. If manual
+runs overlap within one family, the row describes the latest-started run; an older
+completion cannot overwrite it. Scheduled runs and “run now” triggers of the scheduler
+retain their own rows and next-run times.

--- a/docs/ops/stream-check-pid.md
+++ b/docs/ops/stream-check-pid.md
@@ -105,3 +105,25 @@ the latest saved status. Sustained interactive demand can delay background scans
 Stable tuner GETs and browser playback of a stream assigned to a TV channel queue
 playback-priority refreshes of that channel's candidates. Browser playback itself
 starts immediately; owned active sources remain protected from status probes.
+
+## ID lookup and signal verification
+
+Channel checks report `network_status` independently of `is_online`:
+
+- `found`: the engine recognized the ID and returned a verifiable session.
+- `not_found`: the engine explicitly reported that the content ID was not found.
+- `unknown` (or null before checking): lookup was inconclusive. A timeout, no peers,
+  generic HTTP 404, or engine outage does not establish permanent network absence.
+
+`is_online=true` now requires both increasing P2P downloads and a bounded HTTP
+media sample containing packets from an identified audio/video stream. Peer counts,
+prebuffering, stream declarations, or download speed alone are insufficient. A
+failed media probe yields no verified signal, including when ffprobe is unavailable.
+This is a snapshot at `last_checked`, not a continuous playback guarantee or a
+browser codec-compatibility test. The configured engine remains the probe route;
+existing active-playback guards and queue priorities still apply.
+
+Catalogue imports leave new IDs unchecked and preserve an existing probe outcome.
+The signal-status migration clears old online/check outcomes because earlier checks
+and imports could mark an ID online without receiving media. Channel records and
+historical audio/bitrate metadata remain. Run channel checks to populate fresh status.

--- a/frontend/src/__tests__/ChannelCardList.test.tsx
+++ b/frontend/src/__tests__/ChannelCardList.test.tsx
@@ -57,7 +57,7 @@ describe('ChannelCardList', () => {
     const card = screen.getByRole('article', { name: 'Alpha Sports' });
 
     expect(within(card).getByText('Sports · TV: Arena TV')).toBeInTheDocument();
-    expect(within(card).getByText('Offline')).toBeInTheDocument();
+    expect(within(card).getByText('No signal verified')).toBeInTheDocument();
     expect(within(card).getByText('Hidden')).toBeInTheDocument();
     expect(within(card).getByText('Checked never')).toBeInTheDocument();
     expect(within(card).getByText('abc123')).toBeInTheDocument();

--- a/frontend/src/__tests__/ChannelTable.test.tsx
+++ b/frontend/src/__tests__/ChannelTable.test.tsx
@@ -122,7 +122,7 @@ describe('ChannelTable', () => {
     expect(screen.getByText(edgeCaseChannel.name)).toBeInTheDocument();
     expect(screen.getByText(edgeCaseChannel.group)).toBeInTheDocument();
     expect(screen.getByRole('group', { name: `Acestream channel actions for ${edgeCaseChannel.name}` })).toBeInTheDocument();
-    expect(screen.getByText('Online')).toBeInTheDocument();
+    expect(screen.getByText('Signal verified')).toBeInTheDocument();
     expect(screen.getByText(formatRelativeTime(edgeCaseChannel.last_checked))).toBeInTheDocument();
     expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
 
@@ -159,7 +159,7 @@ describe('ChannelTable', () => {
     mountTable({
       channels: [
         baseChannel,
-        { ...baseChannel, id: 'acestream-2', name: 'Offline Channel', is_online: false },
+        { ...baseChannel, id: 'acestream-2', name: 'Offline Channel', is_online: false, network_status: 'found' },
         { ...baseChannel, id: 'acestream-3', name: 'Unknown Channel', is_online: null },
       ],
       totalCount: 3,
@@ -168,8 +168,9 @@ describe('ChannelTable', () => {
     const rows = screen.getAllByRole('row');
     const offlineRow = rows.find((row) => within(row).queryByText('Offline Channel')) as HTMLElement;
     const unknownRow = rows.find((row) => within(row).queryByText('Unknown Channel')) as HTMLElement;
-    expect(within(offlineRow).getByText('Offline')).toBeInTheDocument();
-    expect(within(unknownRow).getByText('Unknown')).toBeInTheDocument();
+    expect(within(offlineRow).getByText('ID found')).toBeInTheDocument();
+    expect(within(offlineRow).getByText('No signal verified')).toBeInTheDocument();
+    expect(within(unknownRow).getByText('Not checked')).toBeInTheDocument();
   });
 
   it('exposes play and check status as visible buttons and the rest behind More actions', () => {

--- a/frontend/src/__tests__/ScheduledJobs.test.tsx
+++ b/frontend/src/__tests__/ScheduledJobs.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import ScheduledJobs from '../components/overview/ScheduledJobs';
+import type { BackgroundTaskStatus } from '../services/dashboardService';
+
+const task = (overrides: Partial<BackgroundTaskStatus>): BackgroundTaskStatus => ({
+  task_name: 'activity_log_cleanup', last_run: '2026-09-07T12:00:00Z', next_run: null,
+  status: 'idle', last_error: null, last_result: null, progress: null, ...overrides,
+});
+
+test('shows scalar results, running starts, interruption and never-run jobs', () => {
+  render(<ScheduledJobs tasks={[
+    task({ last_result: 3 }),
+    task({ task_name: 'channel_status', status: 'running' }),
+    task({ task_name: 'epg_refresh', status: 'interrupted', last_error: 'Application stopped before this run completed' }),
+    task({ task_name: 'url_scraping', last_run: null }),
+  ]} />);
+  expect(screen.getByRole('columnheader', { name: 'Last started' })).toBeInTheDocument();
+  expect(screen.getByText('3 entries removed')).toBeInTheDocument();
+  expect(screen.getByText('In progress')).toBeInTheDocument();
+  expect(screen.getByText('Interrupted')).toBeInTheDocument();
+  expect(screen.getByText('Not run yet')).toBeInTheDocument();
+});
+
+test('keeps manual results separate from scheduled next-run time', () => {
+  render(<ScheduledJobs tasks={[
+    task({ task_name: 'epg_refresh', next_run: '2026-09-08T12:00:00Z', last_result: { sources: 2, successful: 2, failed: 0 } }),
+    task({ task_name: 'manual_epg_refresh', last_result: { sources: 1, successful: 1, failed: 0 } }),
+  ]} />);
+  const manualRow = screen.getByRole('row', { name: /Refresh EPG \(manual\)/ });
+  expect(within(manualRow).getByText('1 source refreshed')).toBeInTheDocument();
+  expect(within(manualRow).getByText('—')).toBeInTheDocument();
+  expect(screen.getByText('2 sources refreshed')).toBeInTheDocument();
+});

--- a/frontend/src/components/ChannelTable.tsx
+++ b/frontend/src/components/ChannelTable.tsx
@@ -5,6 +5,7 @@ import { ContentCopy } from '@mui/icons-material';
 import EmptyState from './state/EmptyState';
 import ChannelRowActions, { type ChannelActionHandlers } from './channels/ChannelRowActions';
 import OnlineChip from './channels/OnlineChip';
+import NetworkStatusChip from './channels/NetworkStatusChip';
 import { AcestreamChannel, acestreamChannelService } from '../services/channelService';
 import { shouldDisableGridVirtualization } from '../config/runtime';
 import { formatRelativeTime } from '../utils/format';
@@ -104,9 +105,15 @@ const ChannelTable: React.FC<ChannelTableProps> = ({
         ),
       },
       {
+        field: 'network_status',
+        headerName: 'Network ID',
+        width: 145,
+        renderCell: (params: GridRenderCellParams<AcestreamChannel>) => <NetworkStatusChip status={params.row.network_status} />,
+      },
+      {
         field: 'is_online',
-        headerName: 'Online',
-        width: 110,
+        headerName: 'Signal',
+        width: 145,
         renderCell: (params: GridRenderCellParams<AcestreamChannel>) => <OnlineChip isOnline={params.row.is_online} />,
       },
       {

--- a/frontend/src/components/channels/ChannelCardList.tsx
+++ b/frontend/src/components/channels/ChannelCardList.tsx
@@ -4,6 +4,7 @@ import { ContentCopy } from '@mui/icons-material';
 import EmptyState from '../state/EmptyState';
 import ChannelRowActions, { type ChannelActionHandlers } from './ChannelRowActions';
 import OnlineChip from './OnlineChip';
+import NetworkStatusChip from './NetworkStatusChip';
 import type { AcestreamChannel } from '../../services/channelService';
 import { formatRelativeTime } from '../../utils/format';
 import { formatDateTime } from '../../utils/formatters';
@@ -85,6 +86,7 @@ const ChannelCardList: React.FC<ChannelCardListProps> = ({
             </Stack>
 
             <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+              <NetworkStatusChip status={channel.network_status} />
               <OnlineChip isOnline={channel.is_online} />
               {hidden ? <Chip label="Hidden" size="small" variant="outlined" sx={{ minWidth: 72 }} /> : null}
               <Tooltip title={channel.last_checked ? formatDateTime(channel.last_checked) : 'Never checked'}>

--- a/frontend/src/components/channels/NetworkStatusChip.tsx
+++ b/frontend/src/components/channels/NetworkStatusChip.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Chip, Tooltip } from '@mui/material';
+
+export const networkStatusLabel = (status?: string | null): string =>
+  status === 'found' ? 'ID found' : status === 'not_found' ? 'ID not found' : 'ID unverified';
+
+const NetworkStatusChip: React.FC<{ status?: string | null }> = ({ status }) => (
+  <Tooltip title="Engine lookup at the last check. A timeout does not prove an ID no longer exists.">
+    <Chip size="small" variant="outlined" label={networkStatusLabel(status)} />
+  </Tooltip>
+);
+export default NetworkStatusChip;

--- a/frontend/src/components/channels/OnlineChip.tsx
+++ b/frontend/src/components/channels/OnlineChip.tsx
@@ -9,7 +9,7 @@ export interface OnlineChipProps {
 const OnlineChip: React.FC<OnlineChipProps> = ({ isOnline }) => {
   const theme = useTheme();
   const tone = isOnline === true ? theme.appTokens.status.success : isOnline === false ? theme.appTokens.status.error : null;
-  const label = isOnline === true ? 'Online' : isOnline === false ? 'Offline' : 'Unknown';
+  const label = isOnline === true ? 'Signal verified' : isOnline === false ? 'No signal verified' : 'Not checked';
   return (
     <Chip
       label={label}

--- a/frontend/src/components/overview/ScheduledJobs.tsx
+++ b/frontend/src/components/overview/ScheduledJobs.tsx
@@ -11,6 +11,8 @@ const statusChip = (status: string) => {
   switch (status) {
     case 'running':
       return <Chip size="small" color="info" label="Running" />;
+    case 'interrupted':
+      return <Chip size="small" color="warning" label="Interrupted" />;
     case 'error':
       return <Chip size="small" color="error" label="Error" />;
     case 'removed':
@@ -39,7 +41,7 @@ const ScheduledJobs: React.FC<ScheduledJobsProps> = ({ tasks }) => {
       <TableHead>
         <TableRow>
           <TableCell>Job</TableCell>
-          <TableCell>Last run</TableCell>
+          <TableCell>Last started</TableCell>
           <TableCell>Result</TableCell>
           <TableCell>Next run</TableCell>
           <TableCell>Status</TableCell>
@@ -52,7 +54,7 @@ const ScheduledJobs: React.FC<ScheduledJobsProps> = ({ tasks }) => {
           return (
             <TableRow key={task.task_name}>
               <TableCell data-label="Job">{formatJobName(task.task_name)}</TableCell>
-              <TableCell data-label="Last run">
+              <TableCell data-label="Last started">
                 <Tooltip title={task.last_run ? formatDateTime(task.last_run) : ''}>
                   <span>{formatRelativeTime(task.last_run)}</span>
                 </Tooltip>
@@ -63,7 +65,7 @@ const ScheduledJobs: React.FC<ScheduledJobsProps> = ({ tasks }) => {
                     {task.last_error}
                   </Typography>
                 ) : (
-                  <span>{summary ?? '—'}{progress}</span>
+                  <span>{task.status === 'running' ? 'In progress' : summary ?? (task.last_run ? 'Completed' : 'Not run yet')}{progress}</span>
                 )}
               </TableCell>
               <TableCell data-label="Next run">

--- a/frontend/src/components/player/ChannelPlayerDialog.tsx
+++ b/frontend/src/components/player/ChannelPlayerDialog.tsx
@@ -1,3 +1,4 @@
+import { networkStatusLabel } from '../channels/NetworkStatusChip';
 import React, { useState } from 'react';
 import { Alert, MenuItem, TextField, Typography } from '@mui/material';
 import { useAcestreamChannel } from '../../hooks/useChannels';
@@ -28,7 +29,7 @@ const OpenChannelPlayer: React.FC<ChannelPlayerDialogProps> = (props) => {
           helperText="Default order: online status, then available logo and EPG metadata. Picture quality and buffering are not measured.">
           {!channel.acestream_channels.some((item) => item.id === selectedId) && selectedId ? <MenuItem value={selectedId}>Opened stream · {selectedId}</MenuItem> : null}
           {channel.acestream_channels.map((item, index) => <MenuItem key={item.id} value={item.id} sx={{ whiteSpace: 'normal', overflowWrap: 'anywhere' }}>
-            {index + 1}. {item.name} · {item.is_online === true ? 'Online' : item.is_online === false ? 'Offline' : 'Not checked'} · {item.id.slice(0, 8)}{item.bitrate_bps ? ` · ${formatBitrate(item.bitrate_bps)}` : ''}{item.audio_tracks?.length ? ` · ${item.audio_tracks.length} audio track${item.audio_tracks.length === 1 ? '' : 's'}` : ''}
+            {index + 1}. {item.name} · {networkStatusLabel(item.network_status)} · {item.is_online === true ? 'Signal verified' : item.is_online === false ? 'No signal verified' : 'Signal not checked'} · {item.id.slice(0, 8)}{item.bitrate_bps ? ` · ${formatBitrate(item.bitrate_bps)}` : ''}{item.audio_tracks?.length ? ` · ${item.audio_tracks.length} audio track${item.audio_tracks.length === 1 ? '' : 's'}` : ''}
           </MenuItem>)}
         </TextField>
         <Typography component="h2" variant="h6">Schedule</Typography>

--- a/frontend/src/services/channelService.ts
+++ b/frontend/src/services/channelService.ts
@@ -21,6 +21,7 @@ export interface AcestreamChannel {
   tvg_name?: string;
   m3u_source?: string;
   original_url?: string;
+  network_status?: components['schemas']['AcestreamChannelResponse']['network_status'];
   is_online: boolean | null;
   last_checked?: string;
   check_error?: string;

--- a/frontend/src/services/dashboardService.ts
+++ b/frontend/src/services/dashboardService.ts
@@ -1,15 +1,8 @@
 // Scheduler status used by the Overview page
 import apiClient from './apiClient';
+import type { components } from '../types/api-generated';
 
-export interface BackgroundTaskStatus {
-  task_name: string;
-  last_run: string | null;
-  next_run: string | null;
-  status: string;
-  last_error: string | null;
-  last_result: unknown;
-  progress: { processed?: number; total?: number; percent?: number } | null;
-}
+export type BackgroundTaskStatus = components['schemas']['BackgroundTaskStatus'];
 
 export const getBackgroundTaskStatus = () =>
   apiClient.get<BackgroundTaskStatus[]>('/v1/background-tasks/status');

--- a/frontend/src/types/api-generated.ts
+++ b/frontend/src/types/api-generated.ts
@@ -1087,10 +1087,7 @@ export interface components {
        * @description Acestream channel ID (required, GUID string)
        */
       id: string;
-      /**
-       * Is Online
-       * @default true
-       */
+      /** Is Online */
       is_online?: boolean | null;
       /** Logo */
       logo?: string | null;
@@ -1159,6 +1156,11 @@ export interface components {
       logo?: string | null;
       /** Name */
       name: string;
+      /**
+       * Network Status
+       * @description Last engine ID lookup: found, explicitly not found, or inconclusive; not proof of permanent network existence
+       */
+      network_status?: ("found" | "not_found" | "unknown") | null;
       /** Source Url */
       source_url?: string | null;
       /** Tv Channel Id */
@@ -1388,6 +1390,25 @@ export interface components {
       /** Title */
       title?: string | null;
     };
+    /** BackgroundTaskStatus */
+    BackgroundTaskStatus: {
+      /** Last Error */
+      last_error: string | null;
+      /** Last Result */
+      last_result: unknown;
+      /** Last Run */
+      last_run: string | null;
+      /** Next Run */
+      next_run: string | null;
+      /** Progress */
+      progress?: {
+        [key: string]: unknown;
+      } | null;
+      /** Status */
+      status: string;
+      /** Task Name */
+      task_name: string;
+    };
     /** BaseUrlCreate */
     BaseUrlCreate: {
       /**
@@ -1511,6 +1532,8 @@ export interface components {
       last_checked: string;
       /** Message */
       message: string;
+      /** Network Status */
+      network_status?: ("found" | "not_found" | "unknown") | null;
       /** Status */
       status: string;
     };
@@ -4022,7 +4045,7 @@ export interface operations {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": unknown;
+          "application/json": components["schemas"]["BackgroundTaskStatus"][];
         };
       };
     };

--- a/frontend/src/types/channelTypes.ts
+++ b/frontend/src/types/channelTypes.ts
@@ -25,6 +25,7 @@ export interface ChannelUpdate {
 }
 
 export interface AcestreamChannel extends ChannelBase {
+  network_status?: components['schemas']['AcestreamChannelResponse']['network_status'];
   bitrate_bps?: components['schemas']['AcestreamChannelResponse']['bitrate_bps'];
   bitrate_checked_at?: components['schemas']['AcestreamChannelResponse']['bitrate_checked_at'];
   audio_tracks?: components['schemas']['AcestreamChannelResponse']['audio_tracks'];

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -42,7 +42,9 @@ export const JOB_NAMES: Record<string, string> = {
   v1_epg_programs_migration: 'Migrate v1 EPG programmes',
 };
 
-export const formatJobName = (id: string): string => JOB_NAMES[id] ?? id.replace(/_/g, ' ');
+export const formatJobName = (id: string): string => id.startsWith('manual_')
+  ? `${JOB_NAMES[id.slice(7)] ?? id.slice(7).replace(/_/g, ' ')} (manual)`
+  : JOB_NAMES[id] ?? id.replace(/_/g, ' ');
 
 const num = (value: unknown): number | null => (typeof value === 'number' && Number.isFinite(value) ? value : null);
 const field = (result: unknown, key: string): number | null =>
@@ -51,7 +53,7 @@ const field = (result: unknown, key: string): number | null =>
 /** One sentence describing a job's last result, or null when there is nothing to say. */
 export const summarizeJobResult = (id: string, result: unknown): string | null => {
   if (result === null || result === undefined) return null;
-  switch (id) {
+  switch (id.startsWith('manual_') ? id.slice(7) : id) {
     case 'url_scraping': {
       const processed = field(result, 'processed');
       const failures = field(result, 'failures') ?? 0;


### PR DESCRIPTION
## Changes

Streams could be marked online from playlist imports or increasing P2P download counters even when AceStream never delivered media to the player. Checks now report engine ID lookup separately from signal verification and require identifiable audio/video packets before reporting an online signal. Scraping no longer overwrites probe outcomes. Channel lists and the player source selector display the distinction.

Overview previously kept scheduler history only in memory, recorded run time only on completion, and rejected scalar cleanup results. Persist the latest launch time and outcome, restore history after restart, and label unfinished runs interrupted. Track manual scrapes, EPG refreshes, and channel checks separately, including bulk summaries and protection against older overlapping runs overwriting newer results.

## Migration and operational notes

- Alembic revision `20260907_1500` adds network lookup status and the latest-job-state table.
- Existing online/check flags are reset to unknown because earlier checks and imports did not verify media. Fresh channel checks repopulate them; channel records and historical media metadata remain.
- Timeouts and generic HTTP failures do not prove permanent ID disappearance. Signal verification is a last-check snapshot, not a playback guarantee.
- Historical job outcomes already lost before this change cannot be recovered.

## Validation

- Full local backend run: 1,161 passed and five initial failures. One schema-parity expectation was missing the new `network_status` column; corrected it and all seven schema-parity tests passed. The other four tests passed when rerun outside the sandbox (process inspection, loopback sockets, and shell file descriptors). No unresolved test failures remain.
- Full frontend suite: 67 suites / 388 tests passed.
- Frontend lint, typecheck, and production build passed.
- OpenAPI regeneration and generated-client drift check passed.
- Docs contract checks and strict legacy-path guard passed.
- Earlier quick canonical suite and focused migration, status, media, scheduler, scraper, and EPG regressions passed.

The full wrapper stopped at the initial backend failures; its remaining frontend/build/codegen checks were completed separately. Live La Sexta playback, Playwright E2E, and Docker runtime tests were not run (these are separate from the canonical full profile).
