### PR TITLE
Split diagnostics into scraper and per-service logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,8 @@ Existing shared browser sessions retain their route until teardown. See
 ## Runtime diagnostics
 
 All image flavours inherit bounded console capture from `backend/capture_logs.py`
-in the shared image layer. Preserve Docker console output, child PIDs/exit codes,
+in the shared image layer. Capture scraper, each service and entrypoint output
+in separate rotating logs. Preserve Docker console output, child PIDs/exit codes,
 process-group cleanup and intentional-stop behavior. The DB-independent
 `GET /api/v1/system/diagnostics` endpoint exports bounded fixed-file tails with
 credential masking and normal API-token enforcement, including during startup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,8 @@ Existing shared browser sessions retain their route until teardown. See
 
 ## Runtime diagnostic downloads
 
-Every container flavour captures bounded combined stdout/stderr in `LOG_DIR` via
+Every container flavour captures bounded stdout/stderr in separate scraper,
+service and entrypoint logs in `LOG_DIR` via
 `backend/capture_logs.py`, installed beside the entrypoint. Preserve child PIDs,
 exit codes and supervisor cleanup when modifying capture. The authenticated
 `GET /api/v1/system/diagnostics` ZIP export is DB-independent and available during

--- a/backend/app/services/diagnostics_service.py
+++ b/backend/app/services/diagnostics_service.py
@@ -11,8 +11,12 @@ from threading import Lock
 from zipfile import ZipFile, ZIP_DEFLATED
 
 LIMIT = 256 * 1024
-LOG_NAMES = ('console.log', 'console.log.1', 'console.log.2', 'warp-svc.log', 'debug.log', 'error.log')
-SERVICES = ('acestream', 'acexy', 'ipfs', 'zeronet', 'warp')
+SERVICES = ('acestream', 'acexy', 'ipfs', 'zeronet', 'warp', 'tor')
+CAPTURE_NAMES = ('scraper', 'entrypoint', *SERVICES)
+LOG_NAMES = tuple(
+    f'{name}.log{suffix}'
+    for name in CAPTURE_NAMES for suffix in ('', '.1', '.2')
+) + ('console.log', 'console.log.1', 'console.log.2', 'warp-svc.log', 'debug.log', 'error.log')
 _lock = Lock()
 
 

--- a/backend/capture_logs.py
+++ b/backend/capture_logs.py
@@ -8,8 +8,9 @@ MAX_BYTES = 2 * 1024 * 1024
 BACKUPS = 2
 
 
-def capture(source, console, directory: Path, max_bytes: int = MAX_BYTES) -> None:
-    path = directory / 'console.log'
+def capture(source, console, directory: Path, max_bytes: int = MAX_BYTES,
+            name: str = 'console.log') -> None:
+    path = directory / name
     warned = False
     while chunk := source.readline(8192):
         try:
@@ -21,9 +22,9 @@ def capture(source, console, directory: Path, max_bytes: int = MAX_BYTES) -> Non
             record = datetime.now(timezone.utc).isoformat().encode() + b' ' + chunk
             if path.exists() and path.stat().st_size + len(record) > max_bytes:
                 for index in range(BACKUPS, 0, -1):
-                    old = path if index == 1 else directory / f'console.log.{index - 1}'
+                    old = path if index == 1 else directory / f'{name}.{index - 1}'
                     if old.exists():
-                        old.replace(directory / f'console.log.{index}')
+                        old.replace(directory / f'{name}.{index}')
             # Reopen each time so rotation never leaves a writer on a retired inode.
             fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW, 0o600)
             with os.fdopen(fd, 'ab') as output:
@@ -35,4 +36,4 @@ def capture(source, console, directory: Path, max_bytes: int = MAX_BYTES) -> Non
 
 
 if __name__ == '__main__':
-    capture(sys.stdin.buffer, sys.stdout.buffer, Path(sys.argv[1]))
+    capture(sys.stdin.buffer, sys.stdout.buffer, Path(sys.argv[1]), name=sys.argv[2] if len(sys.argv) > 2 else 'console.log')

--- a/backend/tests/test_diagnostics.py
+++ b/backend/tests/test_diagnostics.py
@@ -86,3 +86,21 @@ def test_export_busy_returns_retryable_error(client):
 
 def test_long_unbroken_log_line_is_safe_to_redact():
     assert redact('x' * LIMIT) == 'x' * LIMIT
+
+
+def test_service_logs_rotate_independently_and_export(tmp_path, monkeypatch):
+    from app.services.diagnostics_service import CAPTURE_NAMES
+
+    monkeypatch.setenv('LOG_DIR', str(tmp_path))
+    for name in CAPTURE_NAMES:
+        data = f'{name} output password=private123\n'.encode() * 20
+        console = BytesIO()
+        capture(BytesIO(data), console, tmp_path, max_bytes=200, name=f'{name}.log')
+        assert console.getvalue() == data
+    with ZipFile(BytesIO(build_bundle())) as archive:
+        for name in CAPTURE_NAMES:
+            for suffix in ('', '.1', '.2'):
+                content = archive.read(f'logs/{name}.log{suffix}').decode()
+                assert f'{name} output' in content
+                assert 'private123' not in content
+                assert (tmp_path / f'{name}.log{suffix}').stat().st_size <= 200

--- a/backend/tests/test_runtime_integration_guards.py
+++ b/backend/tests/test_runtime_integration_guards.py
@@ -741,3 +741,23 @@ def test_engine_has_persistent_supervision():
     entrypoint = (REPO_ROOT / "entrypoint.sh").read_text()
     assert 'supervise_engine "$ACESTREAM_START_COMMAND" &' in entrypoint
     assert 'acestream.supervisor' in entrypoint
+
+
+def test_entrypoint_separates_app_service_and_setup_logs(tmp_path):
+    _entrypoint_env(
+        tmp_path,
+        IMAGE_HAS_ACEXY="true",
+        ENABLE_ACEXY="true",
+        ACEXY_HOST="engine.example",
+        ACEXY_START_COMMAND="printf 'ACEXY_STDOUT_MARKER\\n'; printf 'ACEXY_STDERR_MARKER\\n' >&2",
+    )
+    logs = tmp_path / "logs"
+    scraper = (logs / "scraper.log").read_text()
+    acexy = (logs / "acexy.log").read_text()
+    entrypoint = (logs / "entrypoint.log").read_text()
+    assert "REPORT FFMPEG_BINARY_PATH" in scraper
+    assert "ACEXY_STDOUT_MARKER" in acexy
+    assert "ACEXY_STDERR_MARKER" in acexy
+    assert "ACEXY_STDOUT_MARKER" not in scraper + entrypoint
+    assert "REPORT FFMPEG_BINARY_PATH" not in acexy + entrypoint
+    assert not (logs / "console.log").exists()

--- a/docs/ops/runtime-diagnostics.md
+++ b/docs/ops/runtime-diagnostics.md
@@ -18,16 +18,30 @@ and custom commands that redirect output elsewhere are not captured. Direct sour
 runs without the entrypoint have no console capture; their exports still work and
 mark unavailable logs in the manifest.
 
-The collector stores `console.log` plus two rotated copies under the existing
-`LOG_DIR` (`/app/logs` by default), each bounded to 2 MiB. Rotation is automatic
-and independent of logrotate. Recording failure leaves console output flowing.
-Files survive application and engine restarts; retaining them across container
-replacement requires mounting the log directory. These local files contain raw
-operational output: restrict access to the log volume.
+The collector writes separate files under `LOG_DIR` (`/app/logs` by default):
 
-Exports contain the latest 256 KiB from each of six fixed log filenames, omitting
-missing files and rejecting symlinks and non-regular files. Rotated console copies
-provide recent history, not a guaranteed time window. The manifest records UTC export
+- `scraper.log`: the application, including Uvicorn and background jobs.
+- `acestream.log`, `acexy.log`, `ipfs.log`, `zeronet.log`, `warp.log`, `tor.log`:
+  stdout/stderr and supervisor lifecycle messages for each launched service.
+- `entrypoint.log`: container setup and overall lifecycle messages.
+
+Only processes launched by this container are captured. Disabled services do not
+create new logs; files from earlier runs remain available for troubleshooting.
+Each file has two rotated copies (`.log.1` and `.log.2`), each bounded to 2 MiB
+(up to 48 MiB for all eight collectors). Rotation is automatic and independent of
+logrotate; logrotate handles only the additional native service logs.
+Recording failure leaves console output flowing. Files survive application and
+engine restarts; retaining them across container replacement requires mounting
+the log directory. These local files contain raw operational output: restrict
+access to the log volume.
+
+Exports contain the latest 256 KiB from each fixed log filename and its two
+rotated copies, omitting missing files and rejecting symlinks and non-regular
+files. For upgrade troubleshooting, existing `console.log` and its two rotations
+are still exported, along with native `warp-svc.log`, `debug.log` and `error.log`.
+New runs no longer write combined `console.log` files. The allowlist is bounded
+at 30 files (7.5 MiB of input tails). Rotations provide recent history, not a
+guaranteed time window. The manifest records UTC export
 time, architecture, file availability/truncation, supervisor PIDs/start times and
 intentional Stop state. Linux cgroup v2 memory counters are included when readable,
 including OOM counters; these do not replace host kernel diagnostics.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 LOG_DIR=${LOG_DIR:-/app/logs}
 mkdir -p "$LOG_DIR"
 export LOG_DIR
-# Mirror combined child output without wrapping the supervised processes or
-# changing their PIDs/exit codes. The reader rotates its own bounded files.
+# Keep the original console separate from each collector so service output
+# is never copied into another service log. Redirection preserves child PIDs.
+exec 3>&1
 CAPTURE_SCRIPT="$(dirname "$0")/capture_logs.py"
 if [ ! -f "$CAPTURE_SCRIPT" ]; then
     CAPTURE_SCRIPT="$(dirname "$0")/backend/capture_logs.py"
@@ -15,8 +16,13 @@ if [ -f "$CAPTURE_SCRIPT" ]; then
     # Python images install their interpreter under /usr/local/bin.
     CAPTURE_PYTHON=$(command -v python3 || true)
     if [ -z "$CAPTURE_PYTHON" ]; then CAPTURE_PYTHON=/usr/local/bin/python3; fi
-    exec > >("$CAPTURE_PYTHON" -u "$CAPTURE_SCRIPT" "$LOG_DIR") 2>&1
 fi
+capture_output() {
+    if [ -f "$CAPTURE_SCRIPT" ]; then
+        exec > >("$CAPTURE_PYTHON" -u "$CAPTURE_SCRIPT" "$LOG_DIR" "$1.log" >&3) 2>&1
+    fi
+}
+capture_output entrypoint
 # Supervisor state the app reads to report/restart sidecar services:
 #   <run dir>/<service>.pid      pid of the current launch (session leader)
 #   <run dir>/<service>.started  epoch of the current launch
@@ -34,7 +40,7 @@ mkdir -p "$LOGROTATE_DIR"
 LOGROTATE_CONF="$LOGROTATE_DIR/acestream-services"
 
 cat > "$LOGROTATE_CONF" <<EOF
-$LOG_DIR/*.log {
+$LOG_DIR/warp-svc.log $LOG_DIR/debug.log $LOG_DIR/error.log {
     hourly
     rotate 7
     compress
@@ -83,6 +89,7 @@ shutdown_children() {
 # it again. Only this process signals the child: API requests use marker files,
 # avoiding stale child-pid races during automatic recovery.
 supervise_engine() {
+    capture_output acestream
     local command="$1" inner_pid="" sleeper_pid="" next_launch=0
     local restart_delay="${SUPERVISED_RESTART_DELAY_SECONDS:-5}"
     local state_dir="$SUPERVISOR_RUN_DIR" action status
@@ -176,6 +183,7 @@ supervise_service() {
     local sleeper_pid=""
     local slug
     slug=$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')
+    capture_output "$slug"
 
     trap '
         for p in ${inner_pid:-$(jobs -p)}; do
@@ -579,7 +587,7 @@ wait_for_supervised_exit() {
 
 trap 'shutdown_children "$app_pid" "${child_pids[@]:-}"' INT TERM EXIT
 
-"${APP_COMMAND[@]}" &
+(capture_output scraper; exec "${APP_COMMAND[@]}") &
 app_pid=$!
 
 if wait_for_supervised_exit; then

--- a/scripts/ci/validate_runtime_contract.sh
+++ b/scripts/ci/validate_runtime_contract.sh
@@ -490,8 +490,8 @@ expect_failure_contains \
     env PATH="$BASE_PATH" CURL_LOG_FILE="$TMP_DIR/engine-down-health.log" CURL_FAIL_MATCH="method=get_version" SUPERVISOR_RUN_DIR="$TMP_DIR/unstopped-run" ENABLE_ACESTREAM_ENGINE=true ENABLE_ACEXY=false bash "$HEALTHCHECK_SCRIPT"
 
 if [ -f "$REPO_ROOT/backend/capture_logs.py" ]; then
-    assert_file_contains "$VALIDATION_LOG_DIR/console.log" "AceStream exited with status"
-    assert_file_contains "$VALIDATION_LOG_DIR/console.log" "AceStream stopped by operator"
+    assert_file_contains "$VALIDATION_LOG_DIR/acestream.log" "AceStream exited with status"
+    assert_file_contains "$VALIDATION_LOG_DIR/acestream.log" "AceStream stopped by operator"
 fi
 
 printf 'Runtime contract validation passed.\n'


### PR DESCRIPTION
Diagnostics previously mixed application and sidecar output in `console.log`, making individual service failures hard to follow. Capture now writes `scraper.log`, one log per launched sidecar (AceStream, Acexy, IPFS, ZeroNet, WARP and Tor), and `entrypoint.log` for container setup. Service supervisor messages stay with their service.

Each collector retains two bounded rotations while forwarding output to the Docker console. The diagnostics ZIP includes the separate files and rotations with the existing bounded reads, credential masking, authentication and startup-failure availability. Existing combined logs remain exportable after upgrades. Native logrotate rules exclude collector-owned files so the rotation mechanisms do not interfere. Operator documentation describes filenames and retention.

Validation:
- Focused diagnostics and runtime integration tests: 50 passed.
- Canonical quick suite: passed (78 backend tests, 11 frontend tests, frontend build).
- Strict legacy-path guard, Bash syntax and diff whitespace checks: passed.
- Local runtime contract: passed, including persistent engine recovery, UI lifecycle commands, shutdown cleanup and service log capture. Multi-architecture Docker smoke builds were not run locally.
