### PR TITLE
Isolate channel checks and protect shared playback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,3 +194,16 @@ ID-not-found responses. See `docs/ops/stream-check-pid.md`.
 Scheduled job launch times and outcomes persist in `scheduled_task_states`; restore
 after schema upgrade off the event loop and mark unfinished runs interrupted. Keep
 scalar results valid in the status API. See `docs/ops/scheduled-job-history.md`.
+
+
+## Dedicated checking engine and playback ownership
+
+`ENABLE_ACESTREAM_CHECK_ENGINE=true` opts bundled-engine images into a second
+persistent supervised engine (state `/var/lib/acestream-check`, HTTP 6880,
+legacy API 62063, P2P 8622). Alternatively, `ACE_CHECK_ENGINE_URL` selects an
+external checker. Never fall back to playback when a configured checker fails;
+preserve previous channel results. Keep checker supervision, controls and logs
+independent; checker outage must not fail whole-container health. Direct playback
+uses process-wide source ownership leases across clients; serialize starts with
+final stops, release exactly once, and preserve session ownership across settings
+changes. Acexy owns its sessions. See `docs/ops/stream-check-pid.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,3 +235,16 @@ ID-not-found responses. See `docs/ops/stream-check-pid.md`.
 Scheduled job launch times and outcomes persist in `scheduled_task_states`; restore
 after schema upgrade off the event loop and mark unfinished runs interrupted. Keep
 scalar results valid in the status API. See `docs/ops/scheduled-job-history.md`.
+
+
+## Dedicated checking engine and playback ownership
+
+`ENABLE_ACESTREAM_CHECK_ENGINE=true` opts bundled-engine images into a second
+persistent supervised engine (state `/var/lib/acestream-check`, HTTP 6880,
+legacy API 62063, P2P 8622). Alternatively, `ACE_CHECK_ENGINE_URL` selects an
+external checker. Never fall back to playback when a configured checker fails;
+preserve previous channel results. Keep checker supervision, controls and logs
+independent; checker outage must not fail whole-container health. Direct playback
+uses process-wide source ownership leases across clients; serialize starts with
+final stops, release exactly once, and preserve session ownership across settings
+changes. Acexy owns its sessions. See `docs/ops/stream-check-pid.md`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -379,7 +379,8 @@ COPY --from=acestream-installer /opt/acestream/ /opt/acestream/
 # bionic userland; its ELF interpreter path is hard-coded to /system/bin/linker*.
 # The directory is empty for the native x86_64 engine.
 COPY --from=acestream-installer /opt/acestream-system/ /system/
-RUN mkdir -p /var/lib/acestream /data
+COPY --chmod=755 docker/scripts/start-check-engine /opt/acestream/start-check-engine
+RUN mkdir -p /var/lib/acestream /var/lib/acestream-check /data
 
 # The same start command works for every platform: on x86_64 start-engine is
 # upstream's wrapper; on ARM it is docker/scripts/acestream-android/start-engine

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -116,3 +116,16 @@ normal API-token dependency, and available while startup is failing. Export only
 fixed, bounded regular-file tails; reject symlinks/devices and mask credentials.
 Never add a Docker socket, arbitrary file path input, environment dump or DB export.
 See `docs/ops/runtime-diagnostics.md` for capture and retention behavior.
+
+
+## Dedicated checking engine and playback ownership
+
+`ENABLE_ACESTREAM_CHECK_ENGINE=true` opts bundled-engine images into a second
+persistent supervised engine (state `/var/lib/acestream-check`, HTTP 6880,
+legacy API 62063, P2P 8622). Alternatively, `ACE_CHECK_ENGINE_URL` selects an
+external checker. Never fall back to playback when a configured checker fails;
+preserve previous channel results. Keep checker supervision, controls and logs
+independent; checker outage must not fail whole-container health. Direct playback
+uses process-wide source ownership leases across clients; serialize starts with
+final stops, release exactly once, and preserve session ownership across settings
+changes. Acexy owns its sessions. See `docs/ops/stream-check-pid.md`.

--- a/backend/app/api/endpoints/system.py
+++ b/backend/app/api/endpoints/system.py
@@ -77,13 +77,13 @@ def restart_service(name: str, db: Session = Depends(get_db)):
         ) from exc
 
 
-def _control_engine(action: str, db: Session) -> dict[str, object]:
+def _control_engine(action: str, db: Session, name: str = "acestream") -> dict[str, object]:
     try:
-        return _service(db).control_engine(action)
+        return _service(db).control_engine(action, name)
     except ServiceNotManagedError as exc:
         raise APIError(code="SERVICE_NOT_MANAGED", message=str(exc),
                        status_code=status.HTTP_409_CONFLICT,
-                       context={"service": "acestream"}) from exc
+                       context={"service": name}) from exc
 
 
 @router.post("/services/acestream/start", response_model=ServiceRestartResponse,
@@ -96,6 +96,18 @@ def start_engine(db: Session = Depends(get_db)) -> dict[str, object]:
              status_code=status.HTTP_202_ACCEPTED, summary="Stop AceStream until Start or container restart")
 def stop_engine(db: Session = Depends(get_db)) -> dict[str, object]:
     return _control_engine("stop", db)
+
+
+@router.post("/services/acestream-check/start", response_model=ServiceRestartResponse,
+             status_code=status.HTTP_202_ACCEPTED, summary="Start the supervised checking engine")
+def start_check_engine(db: Session = Depends(get_db)) -> dict[str, object]:
+    return _control_engine("start", db, "acestream-check")
+
+
+@router.post("/services/acestream-check/stop", response_model=ServiceRestartResponse,
+             status_code=status.HTTP_202_ACCEPTED, summary="Stop channel checks until Start or container restart")
+def stop_check_engine(db: Session = Depends(get_db)) -> dict[str, object]:
+    return _control_engine("stop", db, "acestream-check")
 
 
 @router.get("/public-url", response_model=PublicUrlResponse, summary="Origin external clients must use")

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -109,6 +109,8 @@ class Settings(BaseSettings):
     CORS_ORIGINS: Annotated[List[str], NoDecode] = ["http://localhost:3000"]
     FRONTEND_BUILD_PATH: str = "frontend_build"
     ACE_ENGINE_URL: str = "http://localhost:6878"
+    # Explicit probe route; an unavailable checker must never fall back to playback.
+    ACE_CHECK_ENGINE_URL: str = ""
 
     # --- Media integrations (spec 4.3–4.5) ---------------------------------
     # Externally reachable origin (scheme://host[:port]) advertised to tuners,

--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -9,7 +9,7 @@ ServiceState = Literal["running", "unhealthy", "stopped", "disabled", "external"
 
 
 class ServiceStatus(BaseModel):
-    name: str = Field(description="Stable identifier: acestream, acexy, ipfs, zeronet, warp")
+    name: str = Field(description="Stable identifier: acestream, acestream-check, acexy, ipfs, zeronet, warp")
     label: str
     description: str
     state: ServiceState

--- a/backend/app/services/channel_status_service.py
+++ b/backend/app/services/channel_status_service.py
@@ -64,11 +64,12 @@ class ChannelStatusService:
                     return response.status, None, f"Invalid response format: {str(e)}"
 
     def _get_engine_url(self) -> str:
-        url = self.settings_repo.get_setting(self.settings_repo.ACE_ENGINE_URL, None)
+        from app.config.settings import settings
+        url = settings.ACE_CHECK_ENGINE_URL.strip() or self.settings_repo.get_setting(self.settings_repo.ACE_ENGINE_URL, None)
         if not url:
             raise RuntimeError("Acestream Engine URL is not set in the database. Please configure it via the settings API.")
         url = url.strip()
-        if not url.startswith('http'):
+        if not url.startswith(('http://', 'https://')):
             url = f"http://{url}"
         return url.rstrip('/')
 

--- a/backend/app/services/diagnostics_service.py
+++ b/backend/app/services/diagnostics_service.py
@@ -11,7 +11,7 @@ from threading import Lock
 from zipfile import ZipFile, ZIP_DEFLATED
 
 LIMIT = 256 * 1024
-SERVICES = ('acestream', 'acexy', 'ipfs', 'zeronet', 'warp', 'tor')
+SERVICES = ('acestream', 'acestream-check', 'acexy', 'ipfs', 'zeronet', 'warp', 'tor')
 CAPTURE_NAMES = ('scraper', 'entrypoint', *SERVICES)
 LOG_NAMES = tuple(
     f'{name}.log{suffix}'

--- a/backend/app/services/engine_client.py
+++ b/backend/app/services/engine_client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import TracebackType
 from typing import Optional
 from urllib.parse import urlsplit
@@ -16,6 +16,7 @@ import httpx
 
 from app.repositories.settings_repository import SettingsRepository
 from app.schemas.config import PlaybackRouting
+from app.services.playback_ownership import PlaybackLease, source_ownership
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +41,7 @@ class EngineSession:
     command_url: str
     is_live: bool
     managed_by_acexy: bool = False
+    lease: Optional[PlaybackLease] = field(default=None, compare=False, repr=False)
 
 
 @dataclass(frozen=True)
@@ -149,7 +151,14 @@ class EngineClient:
             # stream is its lifecycle; never send JSON/start/stop or a PID.
             url = str(httpx.URL(f"{self.engine_url}/ace/getstream", params={"id": content_id}))
             return EngineSession(content_id, "", url, "", "", True, managed_by_acexy=True)
-        pid = pid or new_pid()
+        source = source_ownership(self.engine_url, content_id)
+        with source.lock:
+            lease = PlaybackLease(source)
+            session = self._start_direct(content_id, pid or new_pid(), lease)
+            source.leases.add(lease)
+            return session
+
+    def _start_direct(self, content_id: str, pid: str, lease: PlaybackLease) -> EngineSession:
         body = self._get_json(
             f"{self.engine_url}/ace/getstream",
             params={"id": content_id, "pid": pid, "format": "json"},
@@ -158,6 +167,7 @@ class EngineClient:
             return EngineSession(
                 content_id=content_id,
                 pid=pid,
+                lease=lease,
                 playback_url=_engine_target(body["playback_url"], "playback_url"),
                 stat_url=_engine_target(body["stat_url"], "stat_url"),
                 command_url=_engine_target(body["command_url"], "command_url"),
@@ -169,6 +179,20 @@ class EngineClient:
     def stop(self, session: EngineSession) -> None:
         if session.managed_by_acexy:
             return
+        if session.lease is None:
+            # Compatibility for injected clients / pre-existing session handles.
+            self._stop_direct(session)
+            return
+        lease = session.lease
+        with lease.source.lock:
+            if lease.released:
+                return
+            lease.released = True
+            lease.source.leases.discard(lease)
+            if not lease.source.leases:
+                self._stop_direct(session)
+
+    def _stop_direct(self, session: EngineSession) -> None:
         # Merge rather than replace: the engine may hand back a command_url
         # that already carries a token or session id in its query.
         url = httpx.URL(session.command_url).copy_merge_params({"method": "stop"})

--- a/backend/app/services/playback_ownership.py
+++ b/backend/app/services/playback_ownership.py
@@ -1,0 +1,44 @@
+"""Process-wide direct-engine ownership across short-lived clients.
+
+Start and final stop for a source share a lock. Network calls happen only in
+worker threads. Weak references keep abandoned handles from growing a permanent
+registry; normal playback always explicitly releases its session.
+"""
+from __future__ import annotations
+
+from _thread import RLock
+from dataclasses import dataclass, field
+from threading import Lock
+from weakref import WeakSet, WeakValueDictionary
+
+import httpx
+
+
+@dataclass(eq=False)
+class SourceOwnership:
+    lock: RLock = field(default_factory=RLock)
+    leases: WeakSet[PlaybackLease] = field(default_factory=WeakSet)
+
+
+@dataclass(eq=False)
+class PlaybackLease:
+    source: SourceOwnership
+    released: bool = False
+
+
+_sources: WeakValueDictionary[tuple[str, str], SourceOwnership] = WeakValueDictionary()
+_registry_lock = Lock()
+
+
+def source_ownership(engine_url: str, content_id: str) -> SourceOwnership:
+    url = httpx.URL(engine_url)
+    # Local factories can use either spelling for the same engine.
+    if url.host in ('localhost', '127.0.0.1', '::1'):
+        url = url.copy_with(host='localhost')
+    key = (str(url).rstrip('/'), content_id.lower())
+    with _registry_lock:
+        source = _sources.get(key)
+        if source is None:
+            source = SourceOwnership()
+            _sources[key] = source
+        return source

--- a/backend/app/services/system_services_service.py
+++ b/backend/app/services/system_services_service.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RUN_DIR = "/run/acestream-scraper"
 PROBE_TIMEOUT_SECONDS = 2.0
-SERVICE_NAMES = ("acestream", "acexy", "ipfs", "zeronet", "warp")
+SERVICE_NAMES = ("acestream", "acestream-check", "acexy", "ipfs", "zeronet", "warp")
 
 
 class ServiceNotFoundError(KeyError):
@@ -253,7 +253,16 @@ class SystemServicesService:
             probe = self._probe_engine(endpoint)
             if installed:
                 distribution, distribution_url = _engine_distribution()
-            label, description = "AceStream engine", "Resolves and plays acestream:// content; used by search and status checks."
+            label, description = "AceStream engine", "Resolves and plays acestream:// content; also checks channels when no dedicated checker is configured."
+            external_possible = True
+        elif name == "acestream-check":
+            installed = _flag("IMAGE_HAS_ACESTREAM")
+            enabled = _flag("ENABLE_ACESTREAM_CHECK_ENGINE")
+            endpoint = (env.get("ACE_CHECK_ENGINE_URL") or settings.ACE_CHECK_ENGINE_URL).strip() or None
+            if endpoint and not endpoint.startswith(("http://", "https://")):
+                endpoint = "http://" + endpoint
+            probe = self._probe_engine(endpoint) if endpoint else ProbeResult(False, "Dedicated checks are not configured")
+            label, description = "AceStream checking engine", "Verifies channel signal independently of playback. No playback fallback on failure."
             external_possible = True
         elif name == "acexy":
             installed = _flag("IMAGE_HAS_ACEXY")
@@ -294,9 +303,12 @@ class SystemServicesService:
             raise ServiceNotFoundError(name)
 
         proc = self.process_info(name)
-        managed = proc.alive or (name == "acestream" and self.engine_supervised())
-        stopped_by_user = name == "acestream" and (self.run_dir / "acestream.stopped").exists()
-        if not installed and not enabled:
+        managed = proc.alive or (name in ("acestream", "acestream-check") and self.engine_supervised(name))
+        stopped_by_user = name in ("acestream", "acestream-check") and (self.run_dir / f"{name}.stopped").exists()
+        if name == "acestream-check" and endpoint and not enabled:
+            state = "external" if probe.ok else "unhealthy"
+            message = probe.message if probe.ok else "Checking engine unavailable; previous channel statuses are preserved."
+        elif not installed and not enabled:
             if external_possible and probe.ok:
                 state, message = "external", f"Not in this image; using an external instance. {probe.message}"
             else:
@@ -340,6 +352,7 @@ class SystemServicesService:
     def _enable_var(name: str) -> str:
         return {
             "acestream": "ENABLE_ACESTREAM_ENGINE",
+            "acestream-check": "ENABLE_ACESTREAM_CHECK_ENGINE",
             "acexy": "ENABLE_ACEXY",
             "ipfs": "ENABLE_IPFS",
             "zeronet": "ENABLE_ZERONET",
@@ -358,35 +371,38 @@ class SystemServicesService:
             raise ServiceNotFoundError(name)
         return self._evaluate(name)
 
-    def engine_supervised(self) -> bool:
+    def engine_supervised(self, name: str = "acestream") -> bool:
         try:
-            pid = int((self.run_dir / "acestream.supervisor").read_text().strip())
+            pid = int((self.run_dir / f"{name}.supervisor").read_text().strip())
         except (OSError, ValueError):
             return False
         return pid > 1 and self._pid_alive(pid)
 
-    def control_engine(self, action: str) -> Dict[str, object]:
+    def control_engine(self, action: str, name: str = "acestream") -> Dict[str, object]:
+        if name not in ("acestream", "acestream-check"):
+            raise ServiceNotFoundError(name)
         if action not in ("start", "stop", "restart"):
             raise ValueError("Unknown engine action")
-        if not self.engine_supervised():
-            raise ServiceNotManagedError("AceStream is not supervised by this container.")
+        label = "AceStream checking engine" if name == "acestream-check" else "AceStream"
+        if not self.engine_supervised(name):
+            raise ServiceNotManagedError(f"{label} is not supervised by this container.")
         # Publish complete commands atomically, including concurrent requests.
         # The supervisor alone signals children and owns the stopped state.
         with tempfile.NamedTemporaryFile(mode="w", dir=self.run_dir, delete=False) as request:
             temporary = Path(request.name)
             request.write(action)
         try:
-            temporary.replace(self.run_dir / "acestream.command")
+            temporary.replace(self.run_dir / f"{name}.command")
         finally:
             temporary.unlink(missing_ok=True)
-        return {"name": "acestream", "success": True, "message": f"AceStream {action} requested."}
+        return {"name": name, "success": True, "message": f"{label} {action} requested."}
 
     # ---------- restart ----------
     def restart(self, name: str) -> Dict[str, object]:
         if name not in SERVICE_NAMES:
             raise ServiceNotFoundError(name)
-        if name == "acestream":
-            return self.control_engine("restart")
+        if name in ("acestream", "acestream-check"):
+            return self.control_engine("restart", name)
         proc = self.process_info(name)
         if not proc.alive or proc.pid is None:
             raise ServiceNotManagedError(

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4137,7 +4137,7 @@
             "type": "string"
           },
           "name": {
-            "description": "Stable identifier: acestream, acexy, ipfs, zeronet, warp",
+            "description": "Stable identifier: acestream, acestream-check, acexy, ipfs, zeronet, warp",
             "title": "Name",
             "type": "string"
           },
@@ -12787,6 +12787,50 @@
           }
         },
         "summary": "Status of the sidecar services",
+        "tags": [
+          "system",
+          "system"
+        ]
+      }
+    },
+    "/api/v1/system/services/acestream-check/start": {
+      "post": {
+        "operationId": "start_check_engine_api_v1_system_services_acestream_check_start_post",
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRestartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Start the supervised checking engine",
+        "tags": [
+          "system",
+          "system"
+        ]
+      }
+    },
+    "/api/v1/system/services/acestream-check/stop": {
+      "post": {
+        "operationId": "stop_check_engine_api_v1_system_services_acestream_check_stop_post",
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceRestartResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Stop channel checks until Start or container restart",
         "tags": [
           "system",
           "system"

--- a/backend/tests/docker/test_acestream_runtime_smoke.py
+++ b/backend/tests/docker/test_acestream_runtime_smoke.py
@@ -120,6 +120,7 @@ def test_scraper_acestream_starts_real_engine(request: pytest.FixtureRequest, pl
             "--platform", platform,
             "--name", container,
             "-e", "ENABLE_ACESTREAM_ENGINE=true",
+            "-e", "ENABLE_ACESTREAM_CHECK_ENGINE=true",
             "-p", f"{host_port}:8000",
             tag,
         ],
@@ -178,6 +179,15 @@ def test_scraper_acestream_starts_real_engine(request: pytest.FixtureRequest, pl
             capture_output=True, text=True, timeout=15,
         )
         assert status.returncode == 0, status.stderr
+
+        # Run both real engines, crash/recover/stop only the checker, and prove
+        # that playback retains its PID and answering API throughout.
+        lifecycle = subprocess.run(
+            ["docker", "exec", "-i", container, "python", "-"],
+            input=(REPO_ROOT / "docker/testdata/check_engine_lifecycle.py").read_text(),
+            capture_output=True, text=True, timeout=150,
+        )
+        assert lifecycle.returncode == 0, lifecycle.stdout + lifecycle.stderr
 
         # A client from a non-RFC1918 range must be admitted now that the
         # entrypoint passes --bind-all (spec: ACESTREAM_BIND_ALL default true).

--- a/backend/tests/test_channel_broadcast_probe.py
+++ b/backend/tests/test_channel_broadcast_probe.py
@@ -48,7 +48,13 @@ async def test_metadata_and_errors_do_not_mean_online(probe, payload):
 
 
 @pytest.mark.asyncio
-async def test_media_packets_confirm_broadcast_and_stop_session(probe, monkeypatch):
+@pytest.mark.parametrize("dedicated", [False, True])
+async def test_media_packets_confirm_broadcast_and_stop_session(probe, monkeypatch, dedicated):
+    engine_url = "http://checker.test:6880" if dedicated else "http://engine.test:6878"
+    if dedicated:
+        from app.config.settings import settings
+        monkeypatch.setattr(settings, "ACE_CHECK_ENGINE_URL", engine_url)
+        probe._get_engine_url = ChannelStatusService._get_engine_url.__get__(probe)
     monkeypatch.setattr('app.services.channel_status_service.asyncio.sleep', AsyncMock())
     media_probe = AsyncMock(return_value={'signal_verified': True})
     monkeypatch.setattr('app.services.channel_status_service.probe_media', media_probe)
@@ -61,12 +67,12 @@ async def test_media_packets_confirm_broadcast_and_stop_session(probe, monkeypat
     result = await probe.check_channel_status(AcestreamChannel(id='a' * 40, name='Example'), identifier='infohash', persist=False)
     assert result['is_online'] is True
     assert result['network_status'] == 'found'
-    media_probe.assert_awaited_once_with('http://engine.test:6878', 'http://engine.test:6878/ace/r/hash/session')
+    media_probe.assert_awaited_once_with(engine_url, f'{engine_url}/ace/r/hash/session')
     calls = probe._fetch_engine_response.call_args_list
     assert calls[0].args[1]['infohash'] == 'a' * 40
     assert 'method' not in calls[0].args[1]
-    assert calls[1].args[0] == 'http://engine.test:6878/ace/stat/hash/session'
-    assert calls[-1].args[:2] == ('http://engine.test:6878/ace/cmd/hash/session', {'method': 'stop'})
+    assert calls[1].args[0] == f'{engine_url}/ace/stat/hash/session'
+    assert calls[-1].args[:2] == (f'{engine_url}/ace/cmd/hash/session', {'method': 'stop'})
     probe.channel_repository.update_channel_status.assert_not_called()
 
 
@@ -293,3 +299,28 @@ def test_catalogue_upsert_does_not_claim_or_overwrite_signal(db_session):
     channel = repo.create_or_update_channel(channel_id=channel.id, name='Listed again')
     assert channel.is_online is False
     assert channel.network_status == 'found'
+
+
+@pytest.mark.asyncio
+async def test_dedicated_checker_down_never_falls_back_to_playback(db_session, monkeypatch):
+    from app.config.settings import settings
+    monkeypatch.setattr(settings, 'ACE_CHECK_ENGINE_URL', 'http://checker.test:6879')
+    service = ChannelStatusService(db_session)
+    service.channel_repository = MagicMock()
+    service._wait_for_engine = AsyncMock(return_value=False)
+    service._fetch_engine_response = AsyncMock()
+    result = await service.check_channel_status(AcestreamChannel(id='f' * 40, name='Example'))
+    service._wait_for_engine.assert_awaited_once_with('http://checker.test:6879')
+    service._fetch_engine_response.assert_not_awaited()
+    service.channel_repository.update_channel_status.assert_not_called()
+    assert result['status'] == 'skipped'
+
+
+def test_probe_endpoint_uses_explicit_route_or_saved_engine(db_session, monkeypatch):
+    from app.config.settings import settings
+    service = ChannelStatusService(db_session)
+    service.settings_repo.set_setting('ace_engine_url', 'http://playback.test:6878')
+    monkeypatch.setattr(settings, 'ACE_CHECK_ENGINE_URL', ' checker.test:6879/ ')
+    assert service._get_engine_url() == 'http://checker.test:6879'
+    monkeypatch.setattr(settings, 'ACE_CHECK_ENGINE_URL', '')
+    assert service._get_engine_url() == 'http://playback.test:6878'

--- a/backend/tests/test_engine_client.py
+++ b/backend/tests/test_engine_client.py
@@ -190,3 +190,102 @@ def test_playback_factory_uses_saved_routing_but_engine_checks_remain_direct(db_
     with playback_client_from_settings(repo) as client:
         assert client.engine_url == 'http://proxy:8080' and client.use_acexy
     assert engine_url_from_settings(repo) == 'http://engine:6878'
+
+
+def _ownership_client(host='engine', events=None):
+    events = events if events is not None else []
+
+    def handle(request):
+        events.append(request)
+        if 'getstream' in request.url.path:
+            pid = request.url.params['pid']
+            return httpx.Response(200, json={'response': {
+                'playback_url': f'http://{host}:6878/ace/r/hash/{pid}',
+                'stat_url': f'http://{host}:6878/ace/stat/hash/{pid}',
+                'command_url': f'http://{host}:6878/ace/cmd/hash/{pid}',
+            }})
+        return httpx.Response(200)
+
+    return EngineClient(f'http://{host}:6878', client=_client(handle)), events
+
+
+def test_shared_source_stop_waits_for_last_owner_across_clients():
+    first, calls = _ownership_client()
+    second, _ = _ownership_client(events=calls)
+    a = first.start(CID)
+    b = second.start(CID)
+    assert a.pid != b.pid
+    first.stop(a)
+    assert len(calls) == 2  # no stop while another viewer owns the source
+    second.stop(b)
+    assert calls[-1].url.params['method'] == 'stop'
+    first.stop(a)
+    second.stop(b)
+    assert len(calls) == 3  # duplicate cleanup cannot stop a later session
+
+
+def test_ownership_is_separate_for_each_engine_and_source():
+    first, calls = _ownership_client()
+    other, other_calls = _ownership_client('checker')
+    a = first.start(CID)
+    b = first.start('b' * 40)
+    c = other.start(CID)
+    first.stop(a)
+    assert len(calls) == 3
+    assert len(other_calls) == 1
+    first.stop(b)
+    other.stop(c)
+    assert len(calls) == 4 and len(other_calls) == 2
+
+
+def test_start_in_flight_prevents_old_viewer_cleanup():
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+
+    first, calls = _ownership_client()
+    a = first.start(CID)
+    entered, release = Event(), Event()
+    second, _ = _ownership_client(events=calls)
+    original = second._start_direct
+
+    def delayed(*args):
+        entered.set()
+        assert release.wait(3)
+        return original(*args)
+
+    second._start_direct = delayed
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            starting = pool.submit(second.start, CID)
+            assert entered.wait(3)
+            stopping = pool.submit(first.stop, a)
+            assert not stopping.done()
+            release.set()
+            b = starting.result(timeout=3)
+            stopping.result(timeout=3)
+        assert len(calls) == 2
+        second.stop(b)
+        assert len(calls) == 3
+    finally:
+        release.set()
+
+
+def test_failed_start_does_not_keep_a_lease():
+    first, calls = _ownership_client()
+    a = first.start(CID)
+    failed = EngineClient('http://engine:6878', client=_client(lambda r: httpx.Response(500)))
+    with pytest.raises(EngineUnavailableError):
+        failed.start(CID)
+    first.stop(a)
+    assert len(calls) == 2
+
+
+def test_cleanup_keeps_original_ownership_after_routing_changes():
+    first, calls = _ownership_client()
+    a = first.start(CID)
+    b = first.start(CID)
+    changed, changed_calls = _ownership_client('different-engine')
+    changed.stop(a)
+    assert not changed_calls
+    changed.stop(b)
+    assert changed_calls[-1].url.host == 'engine'

--- a/backend/tests/test_system_services.py
+++ b/backend/tests/test_system_services.py
@@ -41,7 +41,7 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "ENABLE_ACESTREAM_ENGINE", "ENABLE_ACEXY", "ENABLE_IPFS", "ENABLE_ZERONET", "ENABLE_WARP",
         "SUPERVISOR_RUN_DIR", "IPFS_GATEWAY_URL", "ZERONET_URL",
         "ACEXY_LISTEN_ADDR", "ACEXY_STATUS_PORT",
-        "ACESTREAM_INSTALL_METADATA",
+        "ACESTREAM_INSTALL_METADATA", "ACE_CHECK_ENGINE_URL", "ENABLE_ACESTREAM_CHECK_ENGINE",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -61,6 +61,7 @@ def test_nothing_installed_and_nothing_reachable(tmp_path, monkeypatch):
 
     assert {name: s["state"] for name, s in services.items()} == {
         "acestream": "not-installed",
+        "acestream-check": "not-installed",
         "acexy": "not-installed",
         "ipfs": "not-installed",
         "zeronet": "not-installed",
@@ -159,7 +160,7 @@ def test_endpoints(client, tmp_path, monkeypatch):
     listing = client.get("/api/v1/system/services")
     assert listing.status_code == 200
     body = listing.json()
-    assert [s["name"] for s in body["services"]] == ["acestream", "acexy", "ipfs", "zeronet", "warp"]
+    assert [s["name"] for s in body["services"]] == ["acestream", "acestream-check", "acexy", "ipfs", "zeronet", "warp"]
     assert body["supervised"] is True
 
     assert client.get("/api/v1/system/services/nope").status_code == 404
@@ -308,3 +309,35 @@ def test_status_tolerates_pid_file_removed_during_restart(tmp_path, monkeypatch)
 
     monkeypatch.setattr(Path, "read_text", racing_read)
     assert _service(tmp_path, FakeHttp({})).process_info("acestream").alive is False
+
+
+@pytest.mark.parametrize('action', ['start', 'stop', 'restart'])
+def test_checker_controls_use_independent_mailbox(tmp_path, monkeypatch, action):
+    _clear_env(monkeypatch)
+    service = _service(tmp_path, FakeHttp({}))
+    (tmp_path / 'acestream-check.supervisor').write_text(str(os.getpid()))
+    (tmp_path / 'acestream.command').write_text('start')
+    result = service.control_engine(action, 'acestream-check')
+    assert result['name'] == 'acestream-check'
+    assert (tmp_path / 'acestream-check.command').read_text() == action
+    assert (tmp_path / 'acestream.command').read_text() == 'start'
+
+
+def test_external_checker_failure_is_visible(tmp_path, monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv('ACE_CHECK_ENGINE_URL', 'http://checker.test:6880')
+    result = _service(tmp_path, FakeHttp({})).get_service('acestream-check')
+    assert result['state'] == 'unhealthy'
+    assert result['managed'] is False
+    assert 'preserved' in result['message']
+
+
+@pytest.mark.parametrize('action', ['start', 'stop'])
+def test_checker_control_routes(client, tmp_path, monkeypatch, action):
+    monkeypatch.setenv('SUPERVISOR_RUN_DIR', str(tmp_path))
+    (tmp_path / 'acestream-check.supervisor').write_text(str(os.getpid()))
+    response = client.post(f'/api/v1/system/services/acestream-check/{action}')
+    assert response.status_code == 202
+    assert response.json()['name'] == 'acestream-check'
+    assert (tmp_path / 'acestream-check.command').read_text() == action
+    assert not (tmp_path / 'acestream.command').exists()

--- a/docker/scripts/start-check-engine
+++ b/docker/scripts/start-check-engine
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# One reusable probe engine; fixed private state and non-playback ports on all
+# architectures. Do not inherit the playback command or its extra flags.
+set -euo pipefail
+export ACESTREAM_HOME=/var/lib/acestream-check
+export ACESTREAM_BIND_ALL=false
+export ACESTREAM_HTTP_PORT=6880
+export PYTHONPATH=/opt/acestream/python-deps
+mkdir -p "$ACESTREAM_HOME/cache" "$ACESTREAM_HOME/tmp"
+# TEMP is the Android bootstrap's scratch directory; state-dir also isolates
+# the native engine's lock, identity and discovery files without changing HOME.
+export TEMP="$ACESTREAM_HOME/tmp"
+exec /opt/acestream/start-engine --client-console \
+    --state-dir "$ACESTREAM_HOME" --cache-dir "$ACESTREAM_HOME/cache" \
+    --http-port 6880 --https-port 6881 --api-port 62063 --port 8622 \
+    --cache-auto 0 --cache-max-bytes 268435456 \
+    --live-cache-type disk --live-disk-cache-size 67108864 \
+    --disable-sentry --log-stdout --log-max-size 1048576 --log-backup-count 2

--- a/docker/testdata/check_engine_lifecycle.py
+++ b/docker/testdata/check_engine_lifecycle.py
@@ -1,0 +1,69 @@
+"""Runs inside a disposable container; never point at a serving engine."""
+import json
+import os
+from pathlib import Path
+import time
+import urllib.request
+
+RUN = Path('/run/acestream-scraper')
+
+
+def ready(port):
+    try:
+        url = f'http://127.0.0.1:{port}/webui/api/service?method=get_version'
+        with urllib.request.urlopen(url, timeout=2) as response:
+            return json.load(response)['result']['version']
+    except Exception:
+        return None
+
+
+def pid(name):
+    try:
+        return int((RUN / f'{name}.pid').read_text().strip())
+    except FileNotFoundError:
+        return None
+
+
+def wait_for(predicate, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(1)
+    raise AssertionError('Timed out waiting for engine lifecycle transition')
+
+
+def main():
+    wait_for(lambda: ready(6878) and ready(6880), 75)
+    playback = pid('acestream')
+    checker = pid('acestream-check')
+    assert playback and checker and playback != checker
+    print('Both engines ready:', ready(6878), ready(6880), flush=True)
+    for directory in ('/var/lib/acestream-check', '/var/lib/acestream-check/cache'):
+        assert Path(directory).is_dir()
+    # Android's application identity must also belong to its dedicated home.
+    identity = Path('/var/lib/acestream-check/.device_id')
+    primary_identity = Path('/var/lib/acestream/.device_id')
+    if identity.is_file() and primary_identity.is_file():
+        assert identity.read_text() != primary_identity.read_text()
+
+    os.kill(checker, 9)
+
+    def recovered():
+        assert ready(6878), 'Checker crash affected playback engine API'
+        assert pid('acestream') == playback, 'Playback engine restarted'
+        return pid('acestream-check') not in (None, checker) and ready(6880)
+
+    wait_for(recovered, 40)
+    print('Checker crash recovered without restarting playback', flush=True)
+    request = RUN / 'request.tmp'
+    request.write_text('stop')
+    request.replace(RUN / 'acestream-check.command')
+    wait_for(lambda: pid('acestream-check') is None, 15)
+    assert ready(6878) and pid('acestream') == playback
+    assert (RUN / 'acestream-check.stopped').is_file()
+    print('Checker Stop leaves playback running', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/builder/runtime-options.json
+++ b/docs/builder/runtime-options.json
@@ -357,6 +357,26 @@
       "appliesWhen": "always"
     },
     {
+      "id": "dedicatedCheckEngine",
+      "env": "ENABLE_ACESTREAM_CHECK_ENGINE",
+      "group": "engine",
+      "label": "Separate engine for channel checks",
+      "description": "Runs a second engine with its own state and cache. Isolates checks from playback but uses additional memory and bandwidth. Leave the external checking address empty when enabled.",
+      "type": "boolean",
+      "default": false,
+      "appliesWhen": "engineOn"
+    },
+    {
+      "id": "externalCheckEngine",
+      "env": "ACE_CHECK_ENGINE_URL",
+      "group": "integrations",
+      "label": "External checking engine address",
+      "description": "Optional dedicated AceStream HTTP endpoint for channel checks. Leave empty to use the bundled checker when enabled, otherwise the saved engine address. An unavailable checker never falls back to playback.",
+      "type": "text",
+      "placeholder": "http://checker:6878",
+      "appliesWhen": "always"
+    },
+    {
       "id": "engineBindAll",
       "env": "ACESTREAM_BIND_ALL",
       "group": "engine",
@@ -437,7 +457,7 @@
     "warpCaps": "WARP needs the NET_ADMIN and SYS_ADMIN capabilities plus the /dev/net/tun device.",
     "acexyExternalEngine": "Acexy refuses to start against localhost:6878 when the in-container engine is disabled — point it at your external engine's address.",
     "publicBaseUrl": "Jellyfin, Plex and VLC need an address they can reach: set it under Integrations → Public address, or pass PUBLIC_BASE_URL.",
-    "externalEngineSettings": "The scraper's own engine connection (used for channel status checks) is configured in the web interface under Settings → Acestream Engine URL.",
+    "externalEngineSettings": "The playback engine connection (also used for checks unless a dedicated checker is configured) is configured in the web interface under Settings → Acestream Engine URL.",
     "afterRun": "Then open http://localhost:{webPort} — set the stream base URL and engine URL under Settings, and add source URLs under Scraper."
   }
 }

--- a/docs/ops/runtime-diagnostics.md
+++ b/docs/ops/runtime-diagnostics.md
@@ -21,7 +21,7 @@ mark unavailable logs in the manifest.
 The collector writes separate files under `LOG_DIR` (`/app/logs` by default):
 
 - `scraper.log`: the application, including Uvicorn and background jobs.
-- `acestream.log`, `acexy.log`, `ipfs.log`, `zeronet.log`, `warp.log`, `tor.log`:
+- `acestream.log`, `acestream-check.log` (when the dedicated checker is enabled), `acexy.log`, `ipfs.log`, `zeronet.log`, `warp.log`, `tor.log`:
   stdout/stderr and supervisor lifecycle messages for each launched service.
 - `entrypoint.log`: container setup and overall lifecycle messages.
 

--- a/docs/ops/stream-check-pid.md
+++ b/docs/ops/stream-check-pid.md
@@ -127,3 +127,88 @@ Catalogue imports leave new IDs unchecked and preserve an existing probe outcome
 The signal-status migration clears old online/check outcomes because earlier checks
 and imports could mark an ID online without receiving media. Channel records and
 historical audio/bitrate metadata remain. Run channel checks to populate fresh status.
+
+## Dedicated checking engine (opt-in)
+
+On `scraper-acestream` and `scraper-acestream-acexy`, set
+`ENABLE_ACESTREAM_ENGINE=true` and `ENABLE_ACESTREAM_CHECK_ENGINE=true` to run
+one persistent checking engine alongside playback. The default remains off.
+Every status caller (manual, search verification, tuner refresh and scheduled
+scan) uses `ACE_CHECK_ENGINE_URL`; the entrypoint supplies
+`http://127.0.0.1:6880` for the bundled checker. Other flavors can set an external
+`ACE_CHECK_ENGINE_URL` instead. Do not combine an external URL with the bundled
+checker switch. The saved Engine URL, Acexy upstream and playback routing retain
+their existing roles. Restart the container after changing these environment options.
+
+The checker has separate state, identity, locks, cache and scratch storage under
+`/var/lib/acestream-check` on every architecture. Its HTTP, legacy API and P2P
+ports are 6880, 62063 and 8622 respectively (HTTPS reserves 6881); playback defaults
+remain 6878, 62062 and 8621. No checking ports are published by the command builder. Reserve these
+ports when customizing the playback command. The checker always uses the packaged
+foreground launcher, independently of `ACESTREAM_START_COMMAND`. Never mount the
+same host directory for playback and checking state. An optional separate mount
+at `/var/lib/acestream-check` keeps its writes outside the writable image layer.
+
+The checker uses a 256 MiB disk-cache limit and 64 MiB live-cache size; these are
+engine cache settings, not a cap on total process RSS. Checks still share one
+probe slot and cooldown. Both processes consume host CPU, RAM and bandwidth;
+isolation prevents checker session stops/crashes from controlling playback, but
+does not remove resource contention or prove that either engine can play a stream
+continuously. Existing active-source guards remain conservative even on the
+separate route, avoiding duplicate traffic for app-owned playback.
+
+Overview → Services exposes **AceStream checking engine** with independent
+Start/Stop/Restart controls. All exits are retried indefinitely, except after UI
+Stop. Start/Restart or container restart resumes recovery. An unavailable checker
+causes checks to be skipped and stored status/timestamps to be preserved. It never
+falls back to the playback engine. Checker health appears in Services and probes;
+it deliberately does not fail container health, which could cause an external
+watchdog to restart healthy playback. Diagnostics include bounded
+`acestream-check.log` tails and separate supervisor state.
+
+## Shared direct-playback cleanup
+
+Direct `EngineClient` sessions now hold a process-wide ownership lease keyed by
+engine endpoint and source ID. Start and final Stop use the same per-source lock
+in worker threads, so a viewer starting while another closes cannot slip between
+the ownership check and the stop request. Closing a viewer releases its lease;
+only the last owner sends the engine Stop command. Repeated cleanup is idempotent,
+and each handle retains its original ownership through configuration changes.
+Browser session sharing and unique PIDs for newly created sessions remain intact.
+Acexy continues to own its sessions and receives no direct Stop commands.
+
+This covers app-owned direct browser and relay sessions, including distinct audio
+selections. It cannot track clients launched directly into an external player,
+resolve arbitrary DNS aliases or map different IDs to the same underlying source.
+Use server relays/Acexy for shared external viewing rather than assuming PID alone
+isolates readers. Cleanup of a released reader while others remain is left to the
+engine until the final owner's Stop; this is intentional.
+
+### Verification — 2026-09-07 working-tree implementation
+
+Implemented against base commit `3abe5ae`. Disposable containers used the existing
+bundled native amd64 **3.2.11** and
+ARM64 **3.2.17** binaries with the updated entrypoint/checker launcher mounted
+read-only. Both engines answered independently. Killing the checker triggered
+recovery; stopping it left the primary engine PID and API unchanged. Fresh ARM64
+homes produce independent device IDs. The native engine reserves HTTPS 6879 by
+default: using that as the second HTTP port makes it reset its port configuration.
+The checker therefore uses HTTP 6880 and explicitly reserves HTTPS 6881.
+
+A native live source (`is_live=1`) continued delivering bytes after the checker
+stopped the same infohash: 17,760,256 → 21,954,560 bytes over eight seconds.
+Using the updated `EngineClient` ownership implementation for two direct sessions
+with distinct PIDs, closing the second viewer left the first receiving media:
+14,614,528 → 18,808,832 bytes over eight seconds. This is a bounded reproduction,
+not a sustained-load guarantee. ARM64 refused the media attempt with
+`mod_detected`; its lifecycle isolation is verified, media isolation remains
+unverified. ARMv7 still needs real hardware.
+
+`backend/tests/docker/test_acestream_runtime_smoke.py` now exercises the dual-engine
+lifecycle through `docker/testdata/check_engine_lifecycle.py` in each freshly built
+runnable image. The full Docker build matrix was not rerun locally for this change.
+Focused ownership, probe-routing, player, tuner, service-control and UI regression
+checks accompany the implementation. The quick gate's committed-type comparison
+requires the newly regenerated API snapshot to be committed; regeneration was
+checked separately for byte-for-byte reproducibility, and the remaining quick
+frontend tests, lint, typecheck and build were run directly.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -89,15 +89,18 @@ shutdown_children() {
 # it again. Only this process signals the child: API requests use marker files,
 # avoiding stale child-pid races during automatic recovery.
 supervise_engine() {
-    capture_output acestream
+    local slug="${2:-acestream}"
+    local label="AceStream"
+    [ "$slug" != acestream-check ] || label="AceStream checker"
+    capture_output "$slug"
     local command="$1" inner_pid="" sleeper_pid="" next_launch=0
     local restart_delay="${SUPERVISED_RESTART_DELAY_SECONDS:-5}"
     local state_dir="$SUPERVISOR_RUN_DIR" action status
     # Always leave a delay on repeated startup failures; never spin or give up.
     case "$restart_delay" in ''|*[!0-9]*) restart_delay=5 ;; esac
     [ "$restart_delay" -ge 1 ] || restart_delay=1
-    rm -f "$state_dir/acestream.pid" "$state_dir/acestream.started" \
-        "$state_dir/acestream.command" "$state_dir/acestream.stopped"
+    rm -f "$state_dir/$slug.pid" "$state_dir/$slug.started" \
+        "$state_dir/$slug.command" "$state_dir/$slug.stopped"
 
     engine_terminate() {
         if [ -n "$inner_pid" ]; then
@@ -113,27 +116,27 @@ supervise_engine() {
             wait "$inner_pid" 2>/dev/null || true
             inner_pid=""
         fi
-        rm -f "$state_dir/acestream.pid" "$state_dir/acestream.started"
+        rm -f "$state_dir/$slug.pid" "$state_dir/$slug.started"
     }
-    trap 'trap "" INT TERM; [ -z "$sleeper_pid" ] || kill "$sleeper_pid" 2>/dev/null || true; engine_terminate; rm -f "$state_dir/acestream.supervisor"; exit 0' INT TERM
+    trap 'trap "" INT TERM; [ -z "$sleeper_pid" ] || kill "$sleeper_pid" 2>/dev/null || true; engine_terminate; rm -f "$state_dir/$slug.supervisor"; exit 0' INT TERM
 
     while :; do
         action=""
-        if [ -f "$state_dir/acestream.command" ]; then
+        if [ -f "$state_dir/$slug.command" ]; then
             # Rename before reading: a concurrent request remains queued for
             # the next iteration instead of being deleted with this request.
-            mv "$state_dir/acestream.command" "$state_dir/acestream.processing"
-            action=$(cat "$state_dir/acestream.processing")
-            rm -f "$state_dir/acestream.processing"
+            mv "$state_dir/$slug.command" "$state_dir/$slug.processing"
+            action=$(cat "$state_dir/$slug.processing")
+            rm -f "$state_dir/$slug.processing"
         fi
         case "$action" in
             stop)
-                touch "$state_dir/acestream.stopped"
+                touch "$state_dir/$slug.stopped"
                 engine_terminate
-                log "AceStream stopped by operator; waiting for Start"
+                log "$label stopped by operator; waiting for Start"
                 ;;
             start|restart)
-                rm -f "$state_dir/acestream.stopped"
+                rm -f "$state_dir/$slug.stopped"
                 if [ "$action" = restart ]; then engine_terminate; fi
                 next_launch=0
                 ;;
@@ -142,18 +145,18 @@ supervise_engine() {
             status=0
             wait "$inner_pid" || status=$?
             engine_terminate
-            log "AceStream exited with status $status; restarting in ${restart_delay}s"
+            log "$label exited with status $status; restarting in ${restart_delay}s"
             next_launch=$(($(date +%s) + restart_delay))
         fi
-        if [ -z "$inner_pid" ] && [ ! -f "$state_dir/acestream.stopped" ] && [ "$(date +%s)" -ge "$next_launch" ]; then
+        if [ -z "$inner_pid" ] && [ ! -f "$state_dir/$slug.stopped" ] && [ "$(date +%s)" -ge "$next_launch" ]; then
             if command -v setsid >/dev/null 2>&1; then
                 setsid bash -lc "$command" &
             else
                 bash -lc "$command" &
             fi
             inner_pid=$!
-            printf '%s\n' "$inner_pid" > "$state_dir/acestream.pid"
-            date +%s > "$state_dir/acestream.started"
+            printf '%s\n' "$inner_pid" > "$state_dir/$slug.pid"
+            date +%s > "$state_dir/$slug.started"
         fi
         sleep 1 &
         sleeper_pid=$!
@@ -440,6 +443,19 @@ if feature_enabled "$ENABLE_ACEXY" && ! feature_enabled "$ENABLE_ACESTREAM_ENGIN
 fi
 
 export ACE_ENGINE_URL="${ACE_ENGINE_URL:-http://$ACESTREAM_HTTP_HOST:$ACESTREAM_HTTP_PORT}"
+# Optional checker process: never derive its command from a custom playback
+# command, which may hard-code shared state, ports or background execution.
+ENABLE_ACESTREAM_CHECK_ENGINE=$(normalize_bool "${ENABLE_ACESTREAM_CHECK_ENGINE:-false}")
+export ENABLE_ACESTREAM_CHECK_ENGINE
+export ACE_CHECK_ENGINE_URL="${ACE_CHECK_ENGINE_URL:-}"
+if feature_enabled "$ENABLE_ACESTREAM_CHECK_ENGINE"; then
+    image_has_feature "$IMAGE_HAS_ACESTREAM" || fail "Checking engine requires an image with AceStream"
+    feature_enabled "$ENABLE_ACESTREAM_ENGINE" || fail "Checking engine requires ENABLE_ACESTREAM_ENGINE=true"
+    [ -z "$ACE_CHECK_ENGINE_URL" ] || fail "Choose bundled checking engine or ACE_CHECK_ENGINE_URL, not both"
+    [ "$ACESTREAM_HTTP_PORT" != 6880 ] || fail "Playback HTTP port conflicts with checking engine port 6880"
+    export ACE_CHECK_ENGINE_URL=http://127.0.0.1:6880
+fi
+
 
 log "ZeroNet endpoint for zero:// sources: $ZERONET_URL (embedded node: $ENABLE_ZERONET)"
 log "IPFS gateway for ipfs:// sources: $IPFS_GATEWAY_URL (embedded daemon: $ENABLE_IPFS)"
@@ -555,6 +571,13 @@ if feature_enabled "$ENABLE_ACESTREAM_ENGINE" && [ -n "${ACESTREAM_START_COMMAND
     printf '%s\n' "$!" > "$SUPERVISOR_RUN_DIR/acestream.supervisor"
     child_pids+=("$!")
     child_names+=("AceStream")
+fi
+
+if feature_enabled "$ENABLE_ACESTREAM_CHECK_ENGINE"; then
+    supervise_engine "exec /opt/acestream/start-check-engine" acestream-check &
+    printf '%s\n' "$!" > "$SUPERVISOR_RUN_DIR/acestream-check.supervisor"
+    child_pids+=("$!")
+    child_names+=("AceStream checker")
 fi
 
 if feature_enabled "$ENABLE_ACEXY" && [ -n "${ACEXY_START_COMMAND:-}" ]; then

--- a/frontend/src/__tests__/ServicesPanel.test.tsx
+++ b/frontend/src/__tests__/ServicesPanel.test.tsx
@@ -124,15 +124,15 @@ describe('ServicesPanel', () => {
     expect(screen.getByText('Restarting…')).toBeInTheDocument();
   });
 
-  it.each([false, true])('requests %s engine state and reports pending action', async (stopped) => {
+  it.each([['acestream', false], ['acestream', true], ['acestream-check', false], ['acestream-check', true]] as const)('requests %s stopped=%s state and reports pending action', async (name, stopped) => {
     mockUseSystemServices.mockReturnValue({
-      data: { supervised: true, services: [service({ stopped_by_user: stopped, state: stopped ? 'stopped' : 'running', pid: stopped ? null : 42 })] },
+      data: { supervised: true, services: [service({ name, stopped_by_user: stopped, state: stopped ? 'stopped' : 'running', pid: stopped ? null : 42 })] },
       isLoading: false, isFetching: false, error: null, refetch: jest.fn(),
     });
     mockControlAsync.mockResolvedValue({ success: true, message: 'Action requested.' });
     renderPanel();
     fireEvent.click(screen.getByRole('button', { name: `${stopped ? 'Start' : 'Stop'} AceStream engine` }));
-    await waitFor(() => expect(mockControlAsync).toHaveBeenCalledWith(stopped ? 'start' : 'stop'));
+    await waitFor(() => expect(mockControlAsync).toHaveBeenCalledWith({ action: stopped ? 'start' : 'stop', name }));
     expect(await screen.findByText(stopped ? 'Starting…' : 'Stopping…')).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/systemService.test.ts
+++ b/frontend/src/__tests__/systemService.test.ts
@@ -17,3 +17,11 @@ it.each(['start', 'stop'] as const)('sends engine %s to the lifecycle endpoint',
   await expect(systemService.controlEngine(action)).resolves.toEqual(result);
   expect(apiClient.post).toHaveBeenCalledWith(`/v1/system/services/acestream/${action}`);
 });
+
+
+it('controls the checking engine independently', async () => {
+  const result = { name: 'acestream-check', success: true, message: 'Stopped' };
+  jest.spyOn(apiClient, 'post').mockResolvedValueOnce({ data: result });
+  await expect(systemService.controlEngine('stop', 'acestream-check')).resolves.toEqual(result);
+  expect(apiClient.post).toHaveBeenLastCalledWith('/v1/system/services/acestream-check/stop');
+});

--- a/frontend/src/components/ServicesPanel.tsx
+++ b/frontend/src/components/ServicesPanel.tsx
@@ -129,9 +129,10 @@ const ServicesPanel: React.FC<ServicesPanelProps> = ({ pollIntervalMs = 30_000 }
   };
 
   const handleEngineControl = async (target: ServiceStatus) => {
+    if (target.name !== 'acestream' && target.name !== 'acestream-check') return;
     const action = target.stopped_by_user ? 'start' : 'stop';
     try {
-      const result = await control.mutateAsync(action);
+      const result = await control.mutateAsync({ action, name: target.name });
       showSnackbar(result.message, 'info');
       setWatch({ name: target.name, label: target.label, previousPid: target.pid, action, startedAt: Date.now() });
     } catch (err) {
@@ -260,7 +261,7 @@ const ServicesPanel: React.FC<ServicesPanelProps> = ({ pollIntervalMs = 30_000 }
                       </Button>
                     </span>
                   </Tooltip>
-                  {service.name === 'acestream' && service.managed ? (
+                  {(service.name === 'acestream' || service.name === 'acestream-check') && service.managed ? (
                     <Button
                       size="small"
                       variant="outlined"

--- a/frontend/src/hooks/useSystemServices.ts
+++ b/frontend/src/hooks/useSystemServices.ts
@@ -39,7 +39,7 @@ export const useRestartService = () => {
 export const useControlEngine = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (action: 'start' | 'stop') => systemService.controlEngine(action),
+    mutationFn: ({ action, name }: { action: 'start' | 'stop'; name: 'acestream' | 'acestream-check' }) => systemService.controlEngine(action, name),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: SYSTEM_SERVICES_QUERY_KEY });
     },

--- a/frontend/src/services/systemService.ts
+++ b/frontend/src/services/systemService.ts
@@ -67,8 +67,8 @@ export const systemService = {
     const { data } = await apiClient.post<ServiceRestartResponse>(`${BASE_URL}/services/${name}/restart`);
     return data;
   },
-  controlEngine: async (action: 'start' | 'stop'): Promise<ServiceRestartResponse> => {
-    const { data } = await apiClient.post<ServiceRestartResponse>(`${BASE_URL}/services/acestream/${action}`);
+  controlEngine: async (action: 'start' | 'stop', name: 'acestream' | 'acestream-check' = 'acestream'): Promise<ServiceRestartResponse> => {
+    const { data } = await apiClient.post<ServiceRestartResponse>(`${BASE_URL}/services/${name}/${action}`);
     return data;
   },
   /** Origin that tuners, players and copied links must use to reach this server. */

--- a/frontend/src/types/api-generated.ts
+++ b/frontend/src/types/api-generated.ts
@@ -839,6 +839,14 @@ export interface paths {
      */
     get: operations["list_services_api_v1_system_services_get"];
   };
+  "/api/v1/system/services/acestream-check/start": {
+    /** Start the supervised checking engine */
+    post: operations["start_check_engine_api_v1_system_services_acestream_check_start_post"];
+  };
+  "/api/v1/system/services/acestream-check/stop": {
+    /** Stop channel checks until Start or container restart */
+    post: operations["stop_check_engine_api_v1_system_services_acestream_check_stop_post"];
+  };
   "/api/v1/system/services/acestream/start": {
     /** Start the supervised AceStream engine */
     post: operations["start_engine_api_v1_system_services_acestream_start_post"];
@@ -2714,7 +2722,7 @@ export interface components {
       message: string;
       /**
        * Name
-       * @description Stable identifier: acestream, acexy, ipfs, zeronet, warp
+       * @description Stable identifier: acestream, acestream-check, acexy, ipfs, zeronet, warp
        */
       name: string;
       /**
@@ -6644,6 +6652,28 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["ServicesStatusResponse"];
+        };
+      };
+    };
+  };
+  /** Start the supervised checking engine */
+  start_check_engine_api_v1_system_services_acestream_check_start_post: {
+    responses: {
+      /** @description Successful Response */
+      202: {
+        content: {
+          "application/json": components["schemas"]["ServiceRestartResponse"];
+        };
+      };
+    };
+  };
+  /** Stop channel checks until Start or container restart */
+  stop_check_engine_api_v1_system_services_acestream_check_stop_post: {
+    responses: {
+      /** @description Successful Response */
+      202: {
+        content: {
+          "application/json": components["schemas"]["ServiceRestartResponse"];
         };
       };
     };

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -78,4 +78,7 @@ elif [ "$ENABLE_ACESTREAM_ENGINE" = "true" ] && [ "$engine_stopped" != true ]; t
     curl -fsS "http://${ACESTREAM_HTTP_HOST}:${ACESTREAM_HTTP_PORT}/webui/api/service?method=get_version" > /dev/null || fail "In-container AceStream engine not accessible"
 fi
 
+# The optional checking engine is monitored by its supervisor, Services panel
+# and each bounded channel probe. Do not fail container health on its outage:
+# automatic container replacement would interrupt the healthy playback engine.
 printf 'All health checks passed\n'

--- a/scripts/ci/validate_runtime_contract.sh
+++ b/scripts/ci/validate_runtime_contract.sh
@@ -403,6 +403,16 @@ expect_success \
     env PATH="$BASE_PATH" LOG_DIR="$VALIDATION_LOG_DIR" LOGROTATE_DIR="$TMP_DIR/logrotate" ENABLE_WARP=false IMAGE_HAS_ACESTREAM=false IMAGE_HAS_ACEXY=true ENABLE_ACESTREAM_ENGINE=false ENABLE_ACEXY=true ACEXY_HOST=engine.example ACEXY_PORT=9999 ACEXY_START_COMMAND='sleep 1 &' APP_DONE_FILE="$APP_DONE_FILE" bash "$ENTRYPOINT_SCRIPT" bash -lc 'sleep 0.3; printf done > "$APP_DONE_FILE"'
 [ -f "$APP_DONE_FILE" ] || fail "Entrypoint returned before the main app command completed"
 
+# Reject unsupported or ambiguous checker configurations before launching anything.
+expect_failure_contains \
+    "Checking engine needs a bundled engine image" \
+    "Checking engine requires an image with AceStream" \
+    env PATH="$BASE_PATH" LOG_DIR="$VALIDATION_LOG_DIR" LOGROTATE_DIR="$TMP_DIR/checker-logrotate" ENABLE_WARP=false IMAGE_HAS_ACESTREAM=false ENABLE_ACESTREAM_ENGINE=false ENABLE_ACEXY=false ENABLE_ACESTREAM_CHECK_ENGINE=true bash "$ENTRYPOINT_SCRIPT" true
+expect_failure_contains \
+    "Checking engine rejects a simultaneous external route" \
+    "Choose bundled checking engine or ACE_CHECK_ENGINE_URL, not both" \
+    env PATH="$BASE_PATH" LOG_DIR="$VALIDATION_LOG_DIR" LOGROTATE_DIR="$TMP_DIR/checker-logrotate" ENABLE_WARP=false IMAGE_HAS_ACESTREAM=true ENABLE_ACESTREAM_ENGINE=true ENABLE_ACEXY=false ENABLE_ACESTREAM_CHECK_ENGINE=true ACE_CHECK_ENGINE_URL=http://checker:6880 bash "$ENTRYPOINT_SCRIPT" true
+
 # Persistent engine lifecycle: survive clean/error/signal exits beyond the old
 # fast-exit budget, then honor Stop/Start/Restart through the same UI mailbox.
 ENGINE_TEST_DIR="$TMP_DIR/engine-lifecycle"

--- a/wiki/Docker.md
+++ b/wiki/Docker.md
@@ -352,3 +352,26 @@ docker run -d -p 0.0.0.0:8000:8000 -v "${PWD}/config:/app/config" pipepito/acest
 This mounts your local `./config` directory to the container's `/app/config` directory.
 
 With the engine enabled on ARM, add `-v "${PWD}/acestream_state:/var/lib/acestream"` (or a local directory) so the engine cache is not rebuilt on every container replacement.
+
+### Isolate channel checks from playback
+
+For images containing AceStream, enable `ENABLE_ACESTREAM_CHECK_ENGINE=true`
+alongside `ENABLE_ACESTREAM_ENGINE=true`. This opt-in starts one reusable checking
+engine, with independent state/cache under `/var/lib/acestream-check` and internal
+HTTP port 6880 (HTTPS reserves 6881, legacy API 62063, P2P 8622). Leave these ports unpublished and
+reserve them when customizing playback. You can mount a separate host directory
+at `/var/lib/acestream-check`; never reuse the playback state directory.
+
+Other images can use a separate external engine via `ACE_CHECK_ENGINE_URL`.
+Choose the bundled switch or the external URL, not both. With neither configured,
+checks use the saved engine URL as before. An unavailable dedicated checker
+preserves previous channel results and never sends checks to the playback engine.
+
+Overview → Services provides separate checking-engine Start/Stop/Restart controls.
+Its crashes recover automatically without restarting playback; its health is shown
+there rather than failing the entire container healthcheck. Diagnostic downloads
+include its own rotating log. The checker adds memory and bandwidth usage (256 MiB
+disk-cache limit, 64 MiB live-cache size; total RAM is not capped by these values).
+Checks remain serialized. ARMv7 still requires testing on real hardware.
+See [stream-check isolation](../docs/ops/stream-check-pid.md) for ownership behavior
+and remaining limitations with players connected directly to an engine.


### PR DESCRIPTION
## Scope

Channel checks can interrupt playback on native AceStream even when they use different PIDs. Add an opt-in dedicated checking engine and coordinate direct playback ownership so closing one viewer only sends Stop when the last app-owned viewer releases that source.

- `ENABLE_ACESTREAM_CHECK_ENGINE=true` starts one reusable bundled checker with separate state, cache, ports, supervision and logs. `ACE_CHECK_ENGINE_URL` supports an external checker instead. Checker outages preserve stored channel results without falling back to playback or failing whole-container health.
- Add independent checking-engine Start/Stop/Restart controls to Services, diagnostic capture, generated API types, runtime options and operator documentation.
- Serialize direct-session starts and final stops by engine/source across short-lived clients. Keep unique PIDs, existing active-source probe guards and Acexy ownership behavior.

## Risks

- A second engine adds CPU, memory and bandwidth demand; the option defaults off. Cache settings do not cap total process memory.
- Ownership covers app-managed direct sessions. External players connected directly to an engine and alternate identifiers for the same underlying source remain outside that guarantee.
- ARM64 lifecycle isolation passed, but media verification was refused with `mod_detected`. ARMv7 still needs real hardware. The full Docker build matrix was not rebuilt locally; the existing real-image smoke test now includes dual-engine lifecycle coverage.
- Rollback: disable the checker option and remove any external checker URL to restore the saved engine route, or revert this PR. No database migration is introduced.

## Verification

- After committing and rebasing onto current `develop`, `CI_USE_PREINSTALLED_DEPS=1 bash scripts/ci/run_v2_test_suite.sh --profile quick` passed in full, including the committed generated-types check.

- Focused backend coverage: 213 domain tests passed in the sandbox; the remaining existing stale-ffmpeg cleanup test passed when rerun outside the sandbox. The updated channel-probe suite passed all 35 tests, and diagnostics/service tests passed all 44 tests.
- Frontend: 26 tests passed across ServicesPanel, systemService and the matching quick-gate page tests; lint, typecheck and production build passed.
- Runtime contracts, strict legacy-path guard, Docker manifest metadata, Dockerfile contract and command-builder validation passed. OpenAPI generation was byte-for-byte reproducible.
- Disposable amd64 3.2.11 and ARM64 3.2.17 engines passed independent startup, checker crash/recovery and checker Stop checks using the checked-in lifecycle helper and updated files mounted into existing images.
- Native live media continued after stopping a probe on the separate engine (17,760,256 → 21,954,560 bytes), and after ownership-aware cleanup of a second direct viewer with a distinct PID (14,614,528 → 18,808,832 bytes).

Detailed behavior and dated evidence: `docs/ops/stream-check-pid.md`.
