### PR TITLE
Fix isolated scraper tests and expose develop validation failures

### DIFF
--- a/backend/tests/test_develop_validation_reporting.py
+++ b/backend/tests/test_develop_validation_reporting.py
@@ -1,0 +1,64 @@
+"""Failed gates must remain diagnosable without a Jenkins workspace or rerun."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize("phase", [1, 3])
+def test_gate_retains_failure_output(tmp_path, phase):
+    config = tmp_path / 'gates.json'
+    config.write_text(json.dumps({'version': 'test', 'profiles': {'quick': {'commands': [
+        {'id': 'broken', 'command': "printf 'actual failure\\n'; printf 'warning\\n' >&2; exit 7", 'blocking': True, 'gate_critical': True},
+    ]}}}))
+    logs = tmp_path / 'logs'
+    result = subprocess.run([sys.executable, str(ROOT / f'scripts/phase_gates/phase{phase}_gate_runner.py'),
+        '--config', str(config), '--json-output', *(['--log-dir', str(logs)] if phase == 3 else [])], capture_output=True, text=True, timeout=10)
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report['blocking_failures'] == ['broken']
+    assert report['results'][0]['stdout_tail'] == 'actual failure'
+    assert report['results'][0]['stderr_tail'] == 'warning'
+    if phase == 1:
+        human = subprocess.run([sys.executable, str(ROOT / 'scripts/phase_gates/phase1_gate_runner.py'),
+            '--config', str(config)], capture_output=True, text=True, timeout=10)
+        assert 'actual failure' in human.stdout
+        assert 'warning' in human.stdout
+        return
+    assert '[phase3] Running broken' in result.stderr
+    assert '[phase3] broken: exit 7' in result.stderr
+    assert 'actual failure' in (logs / 'broken.log').read_text()
+    assert 'warning' in (logs / 'broken.log').read_text()
+
+
+@pytest.mark.parametrize('writes_report', [True, False])
+def test_failed_container_preserves_current_artifacts_without_archiving_stale_success(tmp_path, writes_report):
+    pipeline = (ROOT / 'jenkins/develop.Jenkinsfile').read_text()
+    stage = pipeline.split("stage('Full application validation')", 1)[1]
+    shell = stage.split("sh '''", 1)[1].split("'''", 1)[0]
+    (tmp_path / 'phase3-gate-report-full.json').write_text('{"passed":true,"stale":true}')
+    (tmp_path / 'phase3-phase1-full.json').write_text('{"stale":true}')
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    docker = bin_dir / 'docker'
+    docker.write_text('#!/bin/sh\n' + (
+        'printf \'{"passed":false,"current":true}\\n\' > "$WORKSPACE/.ci-develop-artifacts/phase3-gate-report-full.json"\n'
+        if writes_report else '') + 'exit 7\n')
+    docker.chmod(0o755)
+    result = subprocess.run(['bash', '-c', shell], cwd=tmp_path, env={**os.environ,
+        'WORKSPACE': str(tmp_path), 'PR_RUNNER_IMAGE': 'unused', 'PATH': f'{bin_dir}:{os.environ["PATH"]}'},
+        capture_output=True, text=True, timeout=10)
+    assert result.returncode == 7
+    assert 'Application validation failed (exit 7)' in result.stdout
+    assert not (tmp_path / 'phase3-phase1-full.json').exists()
+    current = tmp_path / 'phase3-gate-report-full.json'
+    if writes_report:
+        assert json.loads(current.read_text()) == {'passed': False, 'current': True}
+    else:
+        assert not current.exists()
+    assert "artifacts: '.ci-develop-artifacts/**," in stage

--- a/backend/tests/test_scrapers.py
+++ b/backend/tests/test_scrapers.py
@@ -740,7 +740,7 @@ acestream://8888888888888888888888888888888888888888
         assert rows[0].url == original_url
         assert rows[0].status == "OK"
 
-    def test_base_scraper_extracts_linked_m3u_metadata(self):
+    def test_base_scraper_extracts_linked_m3u_metadata(self, db_session):
         from app.models.url_types import RegularURL
         from app.scrapers.base import BaseScraper
 
@@ -756,7 +756,7 @@ acestream://9999999999999999999999999999999999999999
 """
                 raise AssertionError(f"Unexpected URL: {url}")
 
-        scraper = _FakeScraper(RegularURL(url="https://example.com/page"))
+        scraper = _FakeScraper(RegularURL(url="https://example.com/page"), db=db_session)
         channels, status = asyncio.run(scraper.scrape())
 
         assert status == "OK"
@@ -772,7 +772,7 @@ acestream://9999999999999999999999999999999999999999
             )
         ]
 
-    def test_base_scraper_resolves_relative_m3u_links_for_zeronet_normalized_sources(self):
+    def test_base_scraper_resolves_relative_m3u_links_for_zeronet_normalized_sources(self, db_session):
         from app.models.url_types import ZeronetURL
         from app.scrapers.base import BaseScraper
 
@@ -787,7 +787,7 @@ acestream://cccccccccccccccccccccccccccccccccccccccc
 """
                 raise AssertionError(f"Unexpected URL: {url}")
 
-        scraper = _FakeScraper(ZeronetURL("zero://site/path"))
+        scraper = _FakeScraper(ZeronetURL("zero://site/path"), db=db_session)
         channels, status = asyncio.run(scraper.scrape())
 
         assert status == "OK"

--- a/docs/ops/jenkins-ci.md
+++ b/docs/ops/jenkins-ci.md
@@ -23,6 +23,12 @@ Current job model (adopted 2026-09-04):
 - `acestream-scraper-release` loads `jenkins/release.Jenkinsfile` from `main` and remains manual-only.
 - GitHub Actions workflows are retired; Jenkins is the sole CI/CD implementation.
 
+Develop validation diagnostics:
+
+- Full application validation prints each gate start/result and failed command output, including nested parity test failures. JSON summaries remain machine-readable.
+- Current reports and complete outer gate logs are archived under `.ci-develop-artifacts/` even when the validation container exits nonzero. Root report copies are cleared before validation so an earlier build cannot appear as the current result.
+- Scraper tests that persist URL status must pass the `db_session` fixture to the scraper. The isolated runner has no writable application database; relying on local data or earlier tests can hide failures.
+
 Security boundary:
 
 - Jenkins itself launches on the trusted Docker-capable executor labeled `dorat-nuc-ci`, but fork-controlled files execute only inside disposable restricted containers.

--- a/jenkins/develop.Jenkinsfile
+++ b/jenkins/develop.Jenkinsfile
@@ -80,8 +80,10 @@ set -euo pipefail
 artifact_dir="$WORKSPACE/.ci-develop-artifacts"
 rm -rf "$artifact_dir"
 mkdir -p "$artifact_dir"
+rm -f phase3-gate-report-full.json phase3-phase1-full.json
 host_uid="$(id -u)"
 host_gid="$(id -g)"
+set +e
 docker run --rm \
   --network none \
   --read-only \
@@ -102,13 +104,21 @@ docker run --rm \
   --workdir /workspace \
   "$PR_RUNNER_IMAGE" \
   bash -c 'cp -R /source/. /workspace/ && CI_OUTPUT_DIR=/artifacts bash scripts/ci/run_develop_validation.sh'
-cp "$artifact_dir"/*.json .
+validation_status=$?
+set -e
+for report in "$artifact_dir"/*.json; do
+  if [[ -f "$report" ]]; then cp "$report" .; fi
+done
+if [[ "$validation_status" -ne 0 ]]; then
+  echo "Application validation failed (exit $validation_status); see the gate output and archived .ci-develop-artifacts reports."
+  exit "$validation_status"
+fi
 docker compose config -q
 '''
       }
       post {
         always {
-          archiveArtifacts artifacts: 'phase3-gate-report-full.json, phase3-phase1-full.json', allowEmptyArchive: true
+          archiveArtifacts artifacts: '.ci-develop-artifacts/**, phase3-gate-report-full.json, phase3-phase1-full.json', allowEmptyArchive: true
         }
       }
     }

--- a/scripts/ci/run_develop_validation.sh
+++ b/scripts/ci/run_develop_validation.sh
@@ -23,6 +23,7 @@ CI_USE_PREINSTALLED_DEPS=1 CUTOVER_SKIP_COMPOSE=1 \
   backend/venv/bin/python scripts/phase_gates/phase3_gate_runner.py \
     --profile full \
     --skip-command compose_smoke \
+    --log-dir "$OUTPUT_DIR/gate-logs" \
     --json-output > "$OUTPUT_DIR/phase3-gate-report-full.json"
 gate_status=$?
 set -e
@@ -30,6 +31,20 @@ set -e
 if [[ -f phase3-phase1-full.json ]]; then
   cp phase3-phase1-full.json "$OUTPUT_DIR/phase3-phase1-full.json"
 fi
+
+# Print the captured outcome as well as retaining machine-readable artifacts.
+backend/venv/bin/python - "$OUTPUT_DIR/phase3-gate-report-full.json" "$OUTPUT_DIR/phase3-phase1-full.json" <<'REPORT'
+import json
+import sys
+from pathlib import Path
+from scripts.phase_gates.phase3_gate_runner import print_human_report
+with open(sys.argv[1], encoding="utf-8") as report:
+    print_human_report(json.load(report))
+if Path(sys.argv[2]).is_file():
+    from scripts.phase_gates.phase1_gate_runner import print_human_report as print_parity_report
+    with open(sys.argv[2], encoding="utf-8") as report:
+        print_parity_report(json.load(report))
+REPORT
 
 if [[ "$gate_status" -ne 0 ]]; then
   exit "$gate_status"

--- a/scripts/phase_gates/phase1_gate_runner.py
+++ b/scripts/phase_gates/phase1_gate_runner.py
@@ -60,6 +60,8 @@ def print_human_report(summary: Dict[str, Any]) -> None:
             print(f"  exit: {result['exit_code']}")
         if result["status"] == "failed" and result["stderr_tail"]:
             print(f"  stderr: {result['stderr_tail']}")
+        if result["status"] == "failed" and result.get("stdout_tail"):
+            print(f"  stdout: {result['stdout_tail']}")
         print()
 
     print("Summary:")
@@ -122,6 +124,7 @@ def main() -> int:
             "status": "planned" if args.dry_run else "passed",
             "exit_code": None,
             "stderr_tail": "",
+            "stdout_tail": "",
         }
 
         if not args.dry_run:
@@ -129,8 +132,8 @@ def main() -> int:
             result["exit_code"] = completed.returncode
             result["status"] = "passed" if completed.returncode == 0 else "failed"
             if completed.returncode != 0:
-                stderr_lines = completed.stderr.strip().splitlines()
-                result["stderr_tail"] = stderr_lines[-1] if stderr_lines else ""
+                result["stderr_tail"] = "\n".join(completed.stderr.strip().splitlines()[-80:])[-16000:]
+                result["stdout_tail"] = "\n".join(completed.stdout.strip().splitlines()[-80:])[-16000:]
 
         results.append(result)
 

--- a/scripts/phase_gates/phase3_gate_runner.py
+++ b/scripts/phase_gates/phase3_gate_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -74,7 +75,7 @@ def print_human_report(summary: Dict[str, Any]) -> None:
         if result["status"] == "failed":
             if result["stderr_tail"]:
                 print(f"  stderr: {result['stderr_tail']}")
-            elif result["stdout_tail"]:
+            if result["stdout_tail"]:
                 print(f"  stdout: {result['stdout_tail']}")
         print()
 
@@ -88,6 +89,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run Phase 3 cutover gates.")
     parser.add_argument("--profile", default="quick", help="Gate profile to run (quick|full).")
     parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to gate config file.")
+    parser.add_argument("--log-dir", type=Path, help="Retain complete stdout/stderr for each gate command.")
     parser.add_argument("--json-output", action="store_true", help="Print machine-readable JSON summary.")
     parser.add_argument(
         "--skip-command",
@@ -135,10 +137,18 @@ def main() -> int:
                 "stderr_tail": "",
             })
             continue
+        print(f"[phase3] Running {command['id']}...", file=sys.stderr, flush=True)
         started = time.time()
         completed = run_command(rendered_command, repo_root)
         duration_ms = int((time.time() - started) * 1000)
 
+        print(f"[phase3] {command['id']}: exit {completed.returncode} ({duration_ms} ms)", file=sys.stderr, flush=True)
+        if args.log_dir:
+            args.log_dir.mkdir(parents=True, exist_ok=True)
+            log_name = re.sub(r'[^a-zA-Z0-9_.-]', '_', command['id'])
+            (args.log_dir / f"{log_name}.log").write_text(
+                f"Command: {rendered_command}\nExit: {completed.returncode}\n\nSTDOUT\n{completed.stdout}\nSTDERR\n{completed.stderr}", encoding="utf-8",
+            )
         stdout_lines = completed.stdout.strip().splitlines()
         stderr_lines = completed.stderr.strip().splitlines()
 
@@ -150,8 +160,8 @@ def main() -> int:
             "status": "passed" if completed.returncode == 0 else "failed",
             "exit_code": completed.returncode,
             "duration_ms": duration_ms,
-            "stdout_tail": stdout_lines[-1] if stdout_lines else "",
-            "stderr_tail": stderr_lines[-1] if stderr_lines else "",
+            "stdout_tail": "\n".join(stdout_lines[-80:])[-16000:],
+            "stderr_tail": "\n".join(stderr_lines[-80:])[-16000:],
         }
         results.append(result)
 


### PR DESCRIPTION
Develop's separate scraper/playlist/EPG smoke suite fails in the isolated runner because two scraper tests persist URL status without supplying a test database. Pass their `db_session` explicitly so they no longer depend on writable local application data or test order.

The failure was concealed by captured gate output and `set -e` exiting before reports were copied. Print gate progress and failed output, retain bounded stdout/stderr in parity reports, archive complete outer gate logs and current reports even on failure, and clear stale root reports before validation. Add regression coverage for diagnostic output and failed containers with and without reports.

Validation: reproduced the original two SQLite failures in a network-disabled, read-only, non-root Docker runner. The corrected full develop validation passed in that runner (local ARM64, Python 3.12): 1,206 backend tests, 402 frontend tests across 72 suites, full parity checks, build/type/lint/contracts and runtime validation. Compose smoke remains delegated to the Jenkins host. Focused scraper/reporting tests: 45 passed. Shell syntax and git diff checks passed.
