### PR TITLE
Fix stream timeouts and improve playback diagnostics

### DIFF
--- a/backend/app/api/endpoints/channels.py
+++ b/backend/app/api/endpoints/channels.py
@@ -1,6 +1,7 @@
 """
 API endpoints for channel management
 """
+import asyncio
 import logging
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
@@ -179,7 +180,7 @@ async def get_acestream_channel(acestreamchannel_id: str, db: Session = Depends(
 
 
 @router.post("/{acestreamchannel_id}/check_status", response_model=ChannelStatusResponse)
-async def check_acestream_channel_status(acestreamchannel_id: str, db: Session = Depends(get_db)):
+def check_acestream_channel_status(acestreamchannel_id: str, db: Session = Depends(get_db)):
     """
     Check the online status of a specific Acestream channel via Acestream engine.
     """
@@ -189,7 +190,9 @@ async def check_acestream_channel_status(acestreamchannel_id: str, db: Session =
         raise HTTPException(status_code=404, detail="Channel not found")
 
     status_service = ChannelStatusService(db)
-    result = await status_service.check_channel_status(channel)
+    # FastAPI runs this endpoint in a worker: SQLite lock waits and synchronous
+    # repository calls must not block health, startup diagnostics, or playback.
+    result = asyncio.run(status_service.check_channel_status(channel))
     return result
 
 

--- a/backend/app/config/database.py
+++ b/backend/app/config/database.py
@@ -374,7 +374,20 @@ def backup_sqlite(database_url: Optional[str] = None, label: str = "pre-upgrade"
     try:
         destination = sqlite3.connect(partial)
         try:
-            source.backup(destination)
+            import time
+
+            last_progress = time.monotonic()
+
+            def check_progress(status, remaining, total):
+                nonlocal last_progress
+                now = time.monotonic()
+                if status in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+                    if now - last_progress >= 30.0:
+                        raise TimeoutError("Database backup blocked by another database connection")
+                else:
+                    last_progress = now
+
+            source.backup(destination, pages=256, progress=check_progress, sleep=0.1)
         finally:
             destination.close()
     except BaseException:

--- a/backend/app/services/channel_status_service.py
+++ b/backend/app/services/channel_status_service.py
@@ -118,7 +118,7 @@ class ChannelStatusService:
                     if (previous_downloaded is not None and downloaded > previous_downloaded
                             and state.get('status') in ('dl', 'prebuf', 'buf')):
                         playback_url = self._session_url(engine_url, response.get('playback_url'), 'r')
-                        media = None if self._in_use(channel_id) else await probe_media(engine_url, playback_url)
+                        media = None if self._in_use(channel_id) else await probe_media(engine_url, playback_url, timeout=timeout)
                         if media and media.get('signal_verified') is True:
                             return True, 'Media signal verified', media
                         return False, 'ID found, but no media signal verified before timeout', media

--- a/backend/app/services/player_service.py
+++ b/backend/app/services/player_service.py
@@ -142,9 +142,12 @@ class PlayerService:
         }
 
     def ffmpeg_argv(self, playback_url: str, directory: Path, audio_index: Optional[int] = None) -> List[str]:
+        # Allow the configured startup budget to cover proxy/engine buffering.
+        # The session reaper still enforces startup and media-stall deadlines.
+        read_timeout_us = int(max(20.0, float(self._settings().PLAYER_START_TIMEOUT_SECONDS)) * 1_000_000)
         return [
             str(self.ffmpeg_path()), "-nostdin", "-hide_banner", "-loglevel", "info", "-nostats",
-            "-rw_timeout", "20000000", "-fflags", "+genpts+discardcorrupt",
+            "-rw_timeout", str(read_timeout_us), "-fflags", "+genpts+discardcorrupt",
             "-i", playback_url, "-map", "0:v:0", "-map", f"0:a:{audio_index}" if audio_index is not None else "0:a:0?", "-c:v", "copy", "-c:a", "aac", "-b:a", "160k", "-ac", "2",
             "-f", "hls", "-hls_time", "2", "-hls_list_size", "6", "-hls_delete_threshold", "2",
             "-hls_flags", "delete_segments+independent_segments+omit_endlist+temp_file",

--- a/backend/app/services/stream_bitrate_service.py
+++ b/backend/app/services/stream_bitrate_service.py
@@ -54,7 +54,7 @@ def has_media_packets(payload: dict) -> bool:
     return False
 
 
-async def probe_media(engine_url: str, playback_url: object) -> dict | None:
+async def probe_media(engine_url: str, playback_url: object, *, timeout: float = 10.0) -> dict | None:
     configured = get_settings().FFMPEG_BINARY_PATH
     sibling = Path(configured).with_name("ffprobe") if configured else None
     binary = str(sibling) if sibling and os.access(sibling, os.X_OK) else shutil.which("ffprobe")
@@ -62,12 +62,13 @@ async def probe_media(engine_url: str, playback_url: object) -> dict | None:
         return None
     process = None
     try:
-        async with asyncio.timeout(10):
+        async with asyncio.timeout(timeout + 5.0):
             # Validate every hop before issuing it. ffprobe receives bytes on stdin
             # and cannot fetch URLs or open files embedded in an upstream playlist.
-            async with httpx.AsyncClient(follow_redirects=False, timeout=5) as client:
+            async with httpx.AsyncClient(follow_redirects=False, timeout=httpx.Timeout(timeout, read=None)) as client:
                 url = httpx.URL(playback_url)
                 sample = bytearray()
+                deadline = asyncio.get_running_loop().time() + timeout
                 for _ in range(4):
                     if url.scheme not in ("http", "https") or _host_identity(url.host) != _host_identity(urlsplit(engine_url).hostname):
                         return None
@@ -80,8 +81,11 @@ async def probe_media(engine_url: str, playback_url: object) -> dict | None:
                             continue
                         if response.status_code != 200:
                             return None
-                        with anyio.move_on_after(5):
-                            async for chunk in response.aiter_bytes(64 * 1024):
+                        # Retain partial data on a stalled/slow source. A fixed
+                        # chunk size buffers small arrivals inside httpx, where
+                        # cancellation would discard them before ffprobe sees them.
+                        with anyio.move_on_after(max(0, deadline - asyncio.get_running_loop().time())):
+                            async for chunk in response.aiter_bytes():
                                 sample.extend(chunk[:SAMPLE_BYTES - len(sample)])
                                 if len(sample) >= SAMPLE_BYTES:
                                     break

--- a/backend/app/services/tuner_playback_service.py
+++ b/backend/app/services/tuner_playback_service.py
@@ -100,9 +100,22 @@ async def relay_ranked_streams(
                     with anyio.fail_after(STALL_SECONDS):
                         chunk = await anext(iterator)
                     yield chunk
-            except (EngineRefusedError, EngineUnavailableError, EngineStreamError, StopAsyncIteration, TimeoutError):
+            except (EngineRefusedError, EngineUnavailableError, EngineStreamError, StopAsyncIteration, TimeoutError) as exc:
                 record_source_failure(content_id)
-                logger.info('TV relay source ended content_id=%s experimental_transcoding=%s', content_id, experimental_transcoding)
+                # Do not include upstream exception text: it can contain URLs
+                # with credentials. Keep EOF distinct from our read deadline.
+                reason = (
+                    'read_timeout' if isinstance(exc, TimeoutError) else
+                    'upstream_eof' if isinstance(exc, StopAsyncIteration) else
+                    'engine_refused' if isinstance(exc, EngineRefusedError) else
+                    'engine_unavailable' if isinstance(exc, EngineUnavailableError) else
+                    'upstream_error'
+                )
+                logger.info(
+                    'TV relay source ended content_id=%s reason=%s phase=%s route=%s experimental_transcoding=%s',
+                    content_id, reason, 'streaming' if first_at is not None else 'starting',
+                    'acexy' if engine.use_acexy else 'direct', experimental_transcoding,
+                )
             finally:
                 with anyio.CancelScope(shield=True):
                     await iterator.aclose()

--- a/backend/tests/docker/test_ffmpeg_build.py
+++ b/backend/tests/docker/test_ffmpeg_build.py
@@ -27,7 +27,7 @@ PLATFORMS = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
 # PlayerService.ffmpeg_argv.
 PLAYER_COMMAND = [
     "-nostdin", "-hide_banner", "-loglevel", "info", "-nostats",
-    "-rw_timeout", "20000000", "-fflags", "+genpts+discardcorrupt",
+    "-rw_timeout", "45000000", "-fflags", "+genpts+discardcorrupt",
     "-i", "/f/sample.m2ts",
     "-map", "0:v:0", "-map", "0:a:0?",
     "-c:v", "copy", "-c:a", "aac", "-b:a", "160k", "-ac", "2",

--- a/backend/tests/test_backup_sqlite.py
+++ b/backend/tests/test_backup_sqlite.py
@@ -81,3 +81,24 @@ def test_a_zero_byte_file_left_by_an_older_build_is_not_reused(tmp_path):
     assert taken is not None and taken != str(stale_dir / "scraper.db")
     with sqlite3.connect(taken) as conn:
         assert conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] == 2
+
+
+def test_locked_backup_times_out_and_can_be_retried(tmp_path, monkeypatch):
+    import time
+
+    path = tmp_path / 'scraper.db'
+    url = _database(path)
+    locker = sqlite3.connect(path)
+    locker.execute('BEGIN EXCLUSIVE')
+    ticks = iter([0.0, 31.0])
+    try:
+        # Use a real SQLite lock and advance only the backup's elapsed clock.
+        with monkeypatch.context() as patch:
+            patch.setattr(time, 'monotonic', lambda: next(ticks))
+            with pytest.raises(TimeoutError, match='backup blocked'):
+                backup_sqlite(url)
+        assert not list((tmp_path / 'backups').glob('*/*'))
+    finally:
+        locker.rollback()
+        locker.close()
+    assert backup_sqlite(url) is not None

--- a/backend/tests/test_channel_broadcast_probe.py
+++ b/backend/tests/test_channel_broadcast_probe.py
@@ -67,7 +67,7 @@ async def test_media_packets_confirm_broadcast_and_stop_session(probe, monkeypat
     result = await probe.check_channel_status(AcestreamChannel(id='a' * 40, name='Example'), identifier='infohash', persist=False)
     assert result['is_online'] is True
     assert result['network_status'] == 'found'
-    media_probe.assert_awaited_once_with(engine_url, f'{engine_url}/ace/r/hash/session')
+    media_probe.assert_awaited_once_with(engine_url, f'{engine_url}/ace/r/hash/session', timeout=probe._get_timeout())
     calls = probe._fetch_engine_response.call_args_list
     assert calls[0].args[1]['infohash'] == 'a' * 40
     assert 'method' not in calls[0].args[1]

--- a/backend/tests/test_player_service.py
+++ b/backend/tests/test_player_service.py
@@ -290,7 +290,7 @@ def test_stop_tears_down_quickly(make_service):
 def test_spawn_argv_contains_required_flags(make_service):
     svc = make_service()
     argv = svc.ffmpeg_argv("http://engine/content/x", Path("/tmp/x"))
-    assert argv[:9] == [str(FAKE_FFMPEG), "-nostdin", "-hide_banner", "-loglevel", "info", "-nostats", "-rw_timeout", "20000000", "-fflags"]
+    assert argv[:9] == [str(FAKE_FFMPEG), "-nostdin", "-hide_banner", "-loglevel", "info", "-nostats", "-rw_timeout", "45000000", "-fflags"]
     assert "-c:a" in argv and argv[argv.index("-c:a") + 1] == "aac"
     assert argv[-1] == "/tmp/x/index.m3u8"
 
@@ -623,4 +623,64 @@ def test_web_player_reads_acexy_and_leaves_shared_session_management_to_proxy(ma
             assert await svc.open_session(IH) is session
         finally:
             await svc.stop()
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize('plex_id', [IH, IH2])
+@pytest.mark.parametrize('use_acexy', [False, True])
+def test_stop_watching_preserves_active_plex_relay(make_service, plex_id, use_acexy):
+    """Exercise viewer leave/reaping while the tuner continues consuming bytes."""
+    from app.services.stream_relay import CHUNK_SIZE, RelayRegistry, relay_engine_stream
+    from app.services.player_service import NO_VIEWERS_SECONDS
+
+    stopped = set()
+    stops = []
+
+    def handler(request):
+        if request.url.path == '/ace/getstream':
+            cid = request.url.params['id']
+            pid = request.url.params['pid']
+            return httpx.Response(200, json={'response': {
+                'playback_url': f'http://engine:6878/content/{cid}',
+                'stat_url': f'http://engine:6878/ace/stat/{cid}/{pid}',
+                'command_url': f'http://engine:6878/ace/cmd/{cid}/{pid}',
+                'is_live': 1,
+            }})
+        if '/ace/cmd/' in request.url.path:
+            cid = request.url.path.split('/')[-2]
+            stopped.add(cid)  # Model native engines: stop affects the entire source.
+            stops.append(cid)
+        return httpx.Response(200)
+
+    class Media(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            while plex_id not in stopped:
+                yield b'G' * CHUNK_SIZE
+                await asyncio.sleep(0)
+
+    def factory(**kwargs):
+        return httpx.AsyncClient(transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=Media())), **kwargs)
+
+    svc = make_service(handler=handler, use_acexy=use_acexy)
+    engine = _engine(handler, use_acexy=use_acexy)
+
+    async def run():
+        relay = relay_engine_stream(engine, plex_id, 'Plex', client_factory=factory,
+                                    registry=RelayRegistry())
+        try:
+            browser = await svc.open_session(IH)
+            assert await anext(relay) == b'G' * CHUNK_SIZE
+            svc.leave(browser.id)
+            svc._clock['now'] += NO_VIEWERS_SECONDS + 1
+            await svc._advance_session(browser, svc._clock['now'])
+            assert svc.get(browser.id) is None
+            assert plex_id not in stopped
+            assert await anext(relay) == b'G' * CHUNK_SIZE
+        finally:
+            await relay.aclose()
+            await svc.stop()
+            engine.close()
+        assert stops.count(plex_id) == (0 if use_acexy else 1)
+
     asyncio.run(run())

--- a/backend/tests/test_stream_bitrate.py
+++ b/backend/tests/test_stream_bitrate.py
@@ -107,3 +107,33 @@ def test_signal_and_history_migration_resets_unverified_status(tmp_path):
         assert conn.execute(text('SELECT name, is_online, network_status, bitrate_bps FROM acestream_channels')).one() == ('Existing', None, None, 8000000)
     assert 'scheduled_task_states' in inspect(engine).get_table_names()
     engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('delay,timeout', [(0, 0.05), (5.1, 5.3)])
+async def test_slow_partial_sample_is_preserved_at_deadline(monkeypatch, delay, timeout):
+    import asyncio
+    import json
+    import httpx
+    from unittest.mock import Mock
+
+    class SlowStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            await asyncio.sleep(delay)
+            yield b'G' * 188
+            await asyncio.sleep(10)
+
+    monkeypatch.setattr('app.services.stream_bitrate_service.shutil.which', lambda _: '/mock/ffprobe')
+    factory = httpx.AsyncClient
+    monkeypatch.setattr('app.services.stream_bitrate_service.httpx.AsyncClient',
+        lambda **kwargs: factory(transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, stream=SlowStream())), **kwargs))
+    payload = {'streams': [{'index': 0, 'codec_type': 'video', 'codec_name': 'h264'}],
+               'packets': [{'stream_index': 0, 'size': '100'}]}
+    process = Mock(returncode=0)
+    process.communicate = AsyncMock(return_value=(json.dumps(payload).encode(), b''))
+    monkeypatch.setattr('app.services.stream_bitrate_service.asyncio.create_subprocess_exec',
+                        AsyncMock(return_value=process))
+    result = await probe_media('http://engine', 'http://engine/media', timeout=timeout)
+    assert result['signal_verified'] is True
+    process.communicate.assert_awaited_once_with(b'G' * 188)

--- a/backend/tests/test_tuner_failover.py
+++ b/backend/tests/test_tuner_failover.py
@@ -419,3 +419,26 @@ def test_failed_source_cooldown_expires(monkeypatch):
     assert service.prefer_recovered_sources(['one', 'two']) == ['two', 'one']
     now[0] += service.FAILURE_COOLDOWN_SECONDS
     assert service.prefer_recovered_sources(['one', 'two']) == ['one', 'two']
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('failure,reason', [('eof', 'upstream_eof'), ('timeout', 'read_timeout'), ('transport', 'upstream_error')])
+async def test_source_end_logs_safe_reason_and_route(monkeypatch, caplog, failure, reason):
+    import logging
+
+    async def source(*args, **kwargs):
+        yield b'media'
+        if failure == 'timeout':
+            await asyncio.sleep(10)
+        if failure == 'transport':
+            raise EngineStreamError('http://user:secret@engine/private')
+
+    monkeypatch.setattr('app.services.tuner_playback_service.relay_engine_stream', source)
+    monkeypatch.setattr('app.services.tuner_playback_service.STALL_SECONDS', 0.01)
+    registry = RelayRegistry()
+    claim = registry.try_open('channel', 'Plex', 1)
+    with caplog.at_level(logging.INFO, logger='app.services.tuner_playback_service'):
+        iterator = default_relay_ranked_streams(Mock(use_acexy=True), ['channel'], 'Plex', claim, registry=registry)
+        assert [chunk async for chunk in iterator] == [b'media']
+    assert f'reason={reason} phase=streaming route=acexy' in caplog.text
+    assert 'secret' not in caplog.text

--- a/docs/builder/runtime-options.json
+++ b/docs/builder/runtime-options.json
@@ -4,6 +4,10 @@
   "repoUrl": "https://github.com/Pipepito/acestream-scraper",
   "wikiUrl": "https://github.com/Pipepito/acestream-scraper/wiki",
   "webContainerPort": 8000,
+  "acexy": {
+    "noResponseTimeoutEnv": "ACEXY_NO_RESPONSE_TIMEOUT",
+    "noResponseTimeoutDefault": "30s"
+  },
   "flavors": [
     {
       "id": "scraper-acestream-acexy",

--- a/docs/ops/startup-recovery.md
+++ b/docs/ops/startup-recovery.md
@@ -87,3 +87,9 @@ Filesystem, database initialization, and recovery work run outside the request
 event loop. Shutdown waits for active foreground database work before releasing
 the data lock. Database schema upgrades still belong to Alembic; recovery adds
 no schema revision and never uses `Base.metadata.create_all()`.
+
+Pre-upgrade SQLite backups abort after 30 seconds of continuous busy/locked
+responses instead of retrying indefinitely. Successful copy progress resets this
+lock-wait budget, so large healthy backups may take longer. A failed partial copy
+is removed and startup remains in recovery; the original database is not upgraded.
+Resolve the competing database connection and retry startup to take a fresh backup.

--- a/docs/ops/stream-check-pid.md
+++ b/docs/ops/stream-check-pid.md
@@ -232,3 +232,44 @@ unconfigured engine as disabled, not unhealthy.
 New scraper-only installs default to no playback endpoint. Bundled enabled engines
 retain their internal endpoint. Existing saved URLs are preserved; clear an old
 localhost URL in Playback if the installation no longer has an engine.
+
+### Slow starts and playback timeouts
+
+The media-sampling phase uses the saved `acestream_check_timeout` (default 10
+seconds, maximum 120), followed by up to five seconds for ffprobe. It keeps partial
+HTTP chunks when sampling expires, so a slow or stalled stream can still have its
+received media inspected. The preceding engine-start and statistics phases have
+separate budgets. Checks require identified A/V packets, not just downloaded bytes.
+Sampling uses HTTP and ffprobe stdin; it needs no shared engine temp-file mount.
+`PLAYER_HLS_DIR` is only for the browser player's output playlists and segments.
+
+Bundled Acexy defaults `ACEXY_NO_RESPONSE_TIMEOUT` to `30s` (upstream defaults to
+`10s`); explicit environment values still win. This is independent of the check
+engine and the saved check timeout. For external Acexy, configure that timeout on
+its host. Browser ffmpeg's socket timeout follows `PLAYER_START_TIMEOUT_SECONDS`
+(default 45 seconds, socket minimum 20); the reaper still enforces startup and
+media-stall limits. Allow time beyond the proxy timeout for HLS segment creation.
+An online check on the dedicated engine does not guarantee that the playback
+engine or Acexy can start the same source later. `REMOTE_PLAYER_UNREACHABLE` from
+`/remote-players/.../status` concerns the selected remote device, not browser HLS.
+
+Manual status checks run their database/network work in a worker so a SQLite lock
+wait does not block the serving event loop. This does not eliminate competing
+writers: collect the diagnostics ZIP and the startup stage when investigating
+`database is locked` errors.
+
+### Correlating browser disconnects with tuner failures
+
+`TV relay source ended` includes `reason` (`read_timeout`, `upstream_eof`,
+`engine_refused`, `engine_unavailable`, or `upstream_error`), `phase` (`starting`
+or `streaming`), and `route` (`direct` or `acexy`). Raw upstream exception text is
+excluded because it can contain credentials. Client cancellation is normal
+cleanup and is not classified as a source failure.
+
+Compare the browser's session DELETE with Acexy's per-source `Client stopped`
+and `Stream done` events: leaving a browser session has a grace period before
+its ffmpeg reader is closed. In Acexy mode that reader disconnect is the
+browser's cleanup; the app sends no engine Stop. A tuner failure preceding that
+upstream disconnect does not establish that browser cleanup stopped the tuner.
+The focused player tests exercise browser leave/reaping while the tuner keeps
+reading, for matching and different source IDs in direct and Acexy routing.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -426,6 +426,8 @@ if feature_enabled "$ENABLE_TOR" && ! feature_enabled "$ENABLE_ZERONET"; then
     log "ENABLE_TOR=true has no effect without ENABLE_ZERONET=true; skipping TOR"
 fi
 
+export ACEXY_NO_RESPONSE_TIMEOUT="${ACEXY_NO_RESPONSE_TIMEOUT:-30s}"
+
 if feature_enabled "$ENABLE_ACESTREAM_ENGINE"; then
     export ACEXY_HOST="${ACEXY_HOST:-$ACESTREAM_HTTP_HOST}"
     export ACEXY_PORT="${ACEXY_PORT:-$ACESTREAM_HTTP_PORT}"

--- a/scripts/ci/validate_command_builder.sh
+++ b/scripts/ci/validate_command_builder.sh
@@ -80,6 +80,11 @@ if f"image: {data['image']}:latest" not in compose:
     errors.append(f"docker-compose.yml no longer uses {data['image']}:latest")
 
 # The runtime toggles the page emits must still exist in the entrypoint.
+acexy_timeout = data["acexy"]
+timeout_assignment = '${' + acexy_timeout['noResponseTimeoutEnv'] + ':-' + acexy_timeout['noResponseTimeoutDefault'] + '}'
+if timeout_assignment not in entrypoint:
+    errors.append("Acexy engine-response timeout default differs from entrypoint.sh")
+
 for var in ("ENABLE_ACESTREAM_ENGINE", "ENABLE_ACEXY", "ENABLE_WARP", "ACEXY_HOST", "ACEXY_PORT", "ZERONET_URL", "ENABLE_ZERONET", "ENABLE_IPFS", "IPFS_GATEWAY_URL", "FLASK_PORT", "PUBLIC_BASE_URL", "TUNER_ALLOWED_NETWORKS", "PLAYER_MAX_SESSIONS"):
     if var not in entrypoint:
         errors.append(f"entrypoint.sh no longer references {var}")

--- a/wiki/Docker.md
+++ b/wiki/Docker.md
@@ -386,3 +386,10 @@ Automation. With neither configured, stream status checks are skipped. An extern
 `ACE_CHECK_ENGINE_URL` is a default that can be overridden in Settings; bundled
 checker configuration remains controlled by the container. See
 [stream-check routing](https://github.com/Pipepito/acestream-scraper/blob/develop/docs/ops/stream-check-pid.md#optional-engines-and-settings).
+
+For slow engine startup through Acexy, bundled images default
+`ACEXY_NO_RESPONSE_TIMEOUT=30s`; an explicit value overrides it. External Acexy
+instances need this configured separately. Keep `PLAYER_START_TIMEOUT_SECONDS`
+(default 45 seconds) long enough for the proxy response and initial HLS segments.
+Stream-status sampling uses the timeout saved in Settings and reads through HTTP,
+so it does not require mounting the engine's temporary files into the scraper.


### PR DESCRIPTION
Slow stream starts could be cut short by fixed media-sampling and socket timeouts. Media sampling now uses the configured check timeout and retains partial chunks, bundled Acexy waits 30 seconds for engine responses, and browser ffmpeg follows the configured player startup budget.

Manual stream checks run in a worker so synchronous database lock waits do not block the serving event loop. Pre-upgrade SQLite backups abort after 30 seconds of continuous busy/locked responses and discard incomplete copies, while healthy backup progress resets that budget.

Tuner source-end logs distinguish timeout, EOF, engine refusal/unavailability, and upstream errors, including playback route and phase without exposing upstream exception text. Browser-disconnect regression coverage checks that tuner playback continues for matching and different sources in direct and Acexy modes. The reported intermittent Plex interruption could not be reproduced; this PR does not claim to fix its unconfirmed cause.

Validation:
- 89 focused stream-probe, backup, and channel tests passed.
- Player, player endpoint, startup initialization, and recovery tests passed; the process-inspection-dependent player cleanup test passed with the required local access.
- 99 engine-client, relay, tuner-failover, and player tests passed in the final focused run (startup-sweep tests excluded from that run).
- Isolated local Acexy container test with synthetic streams kept the other reader receiving data after disconnect, for both matching and different channels.
- Command-builder contract, strict legacy-path guard, shell syntax, and diff whitespace checks passed.

Operator documentation and the Docker ffmpeg command contract are updated. Full Docker builds and live deployment were not performed.
