### PR TITLE
Fix scheduled job contention and stream check summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,3 +257,11 @@ Production Pages publication follows successful, non-dry-run latest promotion in
 `github-publish` credential. The publisher verifies promotion metadata and writes
 `release-status.json`; ordinary develop publishes preserve that production
 version. Never update this label on a main merge, canary-only publish or dry run.
+
+
+Scheduled maintenance jobs share a FIFO queue; due jobs show Waiting and run-now
+requests do not duplicate running/waiting jobs. Settings → Automation stores
+optional start times/timezone in `schedule_anchors`, preserving existing intervals.
+Stream-check results distinguish online/offline/skipped/errors; never label the
+exception count as offline. See `docs/ops/scheduled-job-history.md` for clock/DST
+semantics, queue scope and database recovery behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,3 +301,11 @@ Production Pages publication follows successful, non-dry-run latest promotion in
 `github-publish` credential. The publisher verifies promotion metadata and writes
 `release-status.json`; ordinary develop publishes preserve that production
 version. Never update this label on a main merge, canary-only publish or dry run.
+
+
+Scheduled maintenance jobs share a FIFO queue; due jobs show Waiting and run-now
+requests do not duplicate running/waiting jobs. Settings → Automation stores
+optional start times/timezone in `schedule_anchors`, preserving existing intervals.
+Stream-check results distinguish online/offline/skipped/errors; never label the
+exception count as offline. See `docs/ops/scheduled-job-history.md` for clock/DST
+semantics, queue scope and database recovery behavior.

--- a/backend/app/api/endpoints/background_tasks.py
+++ b/backend/app/api/endpoints/background_tasks.py
@@ -40,7 +40,7 @@ def run_channel_status_job(db: Session = Depends(get_db)):
     if outcome == "unavailable":
         raise HTTPException(status_code=503, detail="The stream status job is unavailable. Check the scheduler in Overview.")
     message = (
-        "The stream status job is already running. Follow its progress in Overview."
+        "The stream status job is already running or waiting. Follow its progress in Overview."
         if outcome == "already_running" else
         "Stream status job queued for all active streams. Follow its progress in Overview."
     )

--- a/backend/app/api/endpoints/config.py
+++ b/backend/app/api/endpoints/config.py
@@ -19,11 +19,13 @@ from app.schemas.config import (
     PublicBaseUrlUpdate,
     PlaybackRouting,
     RescrapeIntervalUpdate,
+    ScheduleAnchors,
     SettingResponse,
     SettingsResponse,
 )
 from app.services.config_service import ConfigService
 from app.services.dashboard_config_service import DashboardConfigService
+from app.services.schedule_config_service import ScheduleConfigService
 
 from app.schemas.config import CheckEngineConfig, CheckEngineConfigResponse
 from app.services.check_engine_config_service import CheckEngineConfigService
@@ -41,6 +43,19 @@ def _validate_boolean_string(value: str, setting_name: str) -> None:
     valid_values = {"true", "false", "True", "False", "1", "0"}
     if value not in valid_values:
         raise HTTPException(status_code=422, detail=f"Invalid boolean value for {setting_name}")
+
+
+@router.get("/schedule-anchors", response_model=ScheduleAnchors)
+def get_schedule_anchors(db: Session = Depends(get_db)):
+    return ScheduleConfigService(db).get()
+
+
+@router.put("/schedule-anchors", response_model=ScheduleAnchors)
+def update_schedule_anchors(schedule: ScheduleAnchors, db: Session = Depends(get_db)):
+    if not ScheduleConfigService(db).save(schedule):
+        raise HTTPException(status_code=500, detail="Could not save schedule start times")
+    task_service.configure_schedule(schedule)
+    return schedule
 
 
 @router.get("/playback-routing", response_model=PlaybackRouting)

--- a/backend/app/config/database_retry.py
+++ b/backend/app/config/database_retry.py
@@ -1,0 +1,42 @@
+"""Bounded retries for complete, rolled-back database operations."""
+import sqlite3
+import time
+from functools import wraps
+from sqlalchemy.exc import OperationalError
+
+
+def is_database_locked(exc: Exception) -> bool:
+    return isinstance(exc, OperationalError) and isinstance(exc.orig, sqlite3.OperationalError) and (
+        getattr(exc.orig, "sqlite_errorcode", 0) & 0xFF in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED)
+        or "database is locked" in str(exc.orig)
+    )
+
+
+def retry_database_write(func):
+    """Retry a DB-only method from the beginning; never retry just commit()."""
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        for attempt in range(3):
+            try:
+                return func(self, *args, **kwargs)
+            except Exception as exc:
+                self.db.rollback()
+                if not is_database_locked(exc) or attempt == 2:
+                    raise
+                time.sleep(0.1 * (2 ** attempt))
+    return wrapped
+
+
+async def run_database_write(operation, *args, **kwargs):
+    """Keep the session alive until its worker finishes, even on cancellation."""
+    import asyncio
+    task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # The caller owns the session and may close it in finally. Cancelling an
+        # await cannot stop a worker thread, so finish before releasing ownership.
+        try:
+            await task
+        finally:
+            raise

--- a/backend/app/repositories/channel_repository.py
+++ b/backend/app/repositories/channel_repository.py
@@ -1,6 +1,7 @@
 """
 Repository for channel data operations
 """
+from app.config.database_retry import retry_database_write
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from typing import Dict, Any, Iterable, List, Optional
@@ -407,6 +408,7 @@ class ChannelRepository:
         ).first()
         return dict(row._mapping) if row else None
 
+    @retry_database_write
     def update_channel_status(self, channel_id: str, is_online: bool, error: str = None, *, bitrate_bps: Optional[int] = None, audio_tracks: Optional[list] = None, network_status: str = "unknown") -> AcestreamChannel:
         """Update the online status of a channel"""
         channel = self.get_channel_by_id(channel_id)

--- a/backend/app/repositories/url_repository.py
+++ b/backend/app/repositories/url_repository.py
@@ -1,3 +1,4 @@
+from app.config.database_retry import retry_database_write
 from sqlalchemy.orm import Session
 from sqlalchemy.future import select
 from typing import List, Optional
@@ -10,6 +11,15 @@ class URLRepository:
 
     def __init__(self, db: Session):
         self.db = db
+
+    @retry_database_write
+    def record_scrape_status(self, url: str, candidate_urls: set[str], status: str, error: Optional[str] = None) -> None:
+        record = self.db.query(ScrapedURL).filter(ScrapedURL.url.in_(candidate_urls)).order_by(ScrapedURL.id.asc()).first()
+        if record is None:
+            record = ScrapedURL(url=url)
+        record.update_status(status, error)
+        self.db.add(record)
+        self.db.commit()
 
     def get_all(self, skip: int = 0, limit: int = 100) -> List[ScrapedURL]:
         """Get all ScrapedURLs"""

--- a/backend/app/schemas/config.py
+++ b/backend/app/schemas/config.py
@@ -141,3 +141,21 @@ class CheckEngineConfig(BaseModel):
 
 class CheckEngineConfigResponse(CheckEngineConfig):
     managed: bool = False
+
+
+class ScheduleAnchors(BaseModel):
+    """Optional clock anchors for the existing repeat intervals."""
+    timezone: str = Field("UTC", description="IANA timezone used to interpret start times")
+    url_scraping: Optional[str] = Field(None, pattern=r"^([01]\d|2[0-3]):[0-5]\d$", description="HH:MM anchor; null retains startup-relative scheduling")
+    epg_refresh: Optional[str] = Field(None, pattern=r"^([01]\d|2[0-3]):[0-5]\d$")
+    channel_status: Optional[str] = Field(None, pattern=r"^([01]\d|2[0-3]):[0-5]\d$")
+
+    @field_validator("timezone")
+    @classmethod
+    def valid_timezone(cls, value: str) -> str:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+        try:
+            ZoneInfo(value)
+        except (ZoneInfoNotFoundError, ValueError) as exc:
+            raise ValueError("Use an IANA timezone such as Europe/Madrid or UTC") from exc
+        return value

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -441,20 +441,15 @@ class BaseScraper(ABC):
             else:
                 db = next(get_db())
 
-        from app.models.models import ScrapedURL
+        from app.repositories.url_repository import URLRepository
+        from app.config.database_retry import run_database_write
 
         candidate_urls = {url}
         if self.url_obj is not None:
             candidate_urls.add(self.url_obj.original_url)
             candidate_urls.add(self.url_obj.get_normalized_url())
-
-        url_record = db.query(ScrapedURL).filter(ScrapedURL.url.in_(candidate_urls)).order_by(ScrapedURL.id.asc()).first()
-
-        if not url_record:
-            url_record = ScrapedURL(url=url)
-
-        url_record.update_status(status, error)
-        db.add(url_record)
-        db.commit()
-        if owns_session:
-            db.close()
+        try:
+            await run_database_write(URLRepository(db).record_scrape_status, url, candidate_urls, status, error)
+        finally:
+            if owns_session:
+                db.close()

--- a/backend/app/services/channel_status_service.py
+++ b/backend/app/services/channel_status_service.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Dict, Any, Optional
 from sqlalchemy.orm import Session
 
+from app.config.database_retry import run_database_write
 from app.models.models import AcestreamChannel
 from app.repositories.channel_repository import ChannelRepository
 from app.services.stream_bitrate_service import probe_media
@@ -277,7 +278,7 @@ class ChannelStatusService:
         check_time = datetime.now(timezone.utc)
         error = None if online else message
         if persist:
-            self.channel_repository.update_channel_status(channel.id, online, error, bitrate_bps=media.get("bitrate_bps") if media else None,
+            await run_database_write(self.channel_repository.update_channel_status, channel.id, online, error, bitrate_bps=media.get("bitrate_bps") if media else None,
                 audio_tracks=media.get("audio_tracks") if media else None, network_status=network_status)
         return {
             'channel_id': channel.id,

--- a/backend/app/services/epg_service.py
+++ b/backend/app/services/epg_service.py
@@ -161,7 +161,10 @@ class EPGService:
                     db_channel.language = language
                     db_channel.updated_at = datetime.now(timezone.utc)
 
-            self.db.flush()
+            # Existing channel IDs are already available. Avoid taking SQLite's
+            # writer lock while parsing/diffing a large replacement guide.
+            if channels_found:
+                self.db.flush()
             channel_id_map = {xml_id: channel.id for xml_id, channel in channel_mapping.items()}
 
             existing_programs = (
@@ -615,6 +618,7 @@ class EPGService:
             return result
 
         except Exception as e:
+            self.db.rollback()
             logger.error(f"Error refreshing EPG source {source_id}: {e}")
             duration = (datetime.now() - start_time).total_seconds()
             return {

--- a/backend/app/services/schedule_config_service.py
+++ b/backend/app/services/schedule_config_service.py
@@ -1,0 +1,21 @@
+"""Persist schedule anchors together in the existing settings table."""
+from app.schemas.config import ScheduleAnchors
+from app.repositories.settings_repository import SettingsRepository
+
+
+class ScheduleConfigService:
+    def __init__(self, db):
+        self.repository = SettingsRepository(db)
+
+    def get(self) -> ScheduleAnchors:
+        raw = self.repository.get_setting("schedule_anchors")
+        return ScheduleAnchors.model_validate_json(raw) if raw else ScheduleAnchors()
+
+    def save(self, schedule: ScheduleAnchors) -> bool:
+        return self.repository.set_setting("schedule_anchors", schedule.model_dump_json())
+
+
+def load_schedule_anchors():
+    from app.config.database import SessionLocal
+    with SessionLocal() as db:
+        return ScheduleConfigService(db).get()

--- a/backend/app/services/scraper_service.py
+++ b/backend/app/services/scraper_service.py
@@ -106,6 +106,7 @@ class ScraperService:
             ], status
 
         except Exception as e:
+            self.db.rollback()
             logger.error(f"Error scraping URL {url}: {str(e)}")
             return [], f"Error: {str(e)}"
 

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -4,13 +4,16 @@ Service for managing background tasks using APScheduler in FastAPI.
 import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, Optional
+from app.schemas.config import ScheduleAnchors
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.base import SchedulerAlreadyRunningError, SchedulerNotRunningError
 from apscheduler.triggers.date import DateTrigger
+from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 from apscheduler.jobstores.base import JobLookupError
-from threading import Event, Lock
+from threading import Event, Lock, Condition
+from collections import deque
 import logging
 
 
@@ -21,6 +24,12 @@ class TaskService:
         self.shutdown_event = Event()
         self.logger = logging.getLogger("TaskService")
         self._state_lock = Lock()
+        self._persist_lock = Lock()
+        self._maintenance_condition = Condition()
+        self._maintenance_queue = deque()
+        self._schedule_anchors = {}
+        self._interval_seconds = {}
+        self._schedule_timezone = "UTC"
         self._task_states: Dict[str, Dict[str, Any]] = {}
 
     def _new_scheduler(self) -> BackgroundScheduler:
@@ -51,7 +60,7 @@ class TaskService:
         try:
             states = self._state_store.load()
             for state in states.values():
-                if state["status"] == "running":
+                if state["status"] in {"running", "waiting"}:
                     state["status"] = "interrupted"
                     state["last_error"] = "Application stopped before this run completed"
                     self._state_store.save(state)
@@ -105,8 +114,35 @@ class TaskService:
         self.logger.info("Background scheduler shut down.")
         return True
 
-    def _instrument_task(self, job_id: str, func: Callable[..., Any]) -> Callable[..., Any]:
-        def _runner(*args, **kwargs):
+    def configure_schedule(self, schedule: ScheduleAnchors) -> None:
+        self._schedule_anchors = {
+            name: getattr(schedule, name)
+            for name in ("url_scraping", "epg_refresh", "channel_status")
+        }
+        self._schedule_timezone = schedule.timezone
+        for name in self._schedule_anchors:
+            job = self.scheduler.get_job(name)
+            if job is not None:
+                self.reschedule_task(name, self._interval_seconds[name])
+
+    def _interval_trigger(self, job_id: str, seconds: int) -> IntervalTrigger | CronTrigger:
+        from zoneinfo import ZoneInfo
+        anchor = self._schedule_anchors.get(job_id)
+        if not anchor:
+            return IntervalTrigger(seconds=seconds)
+        hour, minute = map(int, anchor.split(":"))
+        if seconds % 3600 == 0 and 86400 % seconds == 0:
+            hours = sorted({(hour + offset) % 24 for offset in range(0, 24, seconds // 3600)})
+            return CronTrigger(hour=",".join(map(str, hours)), minute=minute, second=0, timezone=self._schedule_timezone)
+        if seconds % 60 == 0 and 3600 % seconds == 0:
+            minutes = sorted({(minute + offset) % 60 for offset in range(0, 60, seconds // 60)})
+            return CronTrigger(minute=",".join(map(str, minutes)), second=0, timezone=self._schedule_timezone)
+        # Stable epoch preserves the cadence across restarts and intervals >24h.
+        start = datetime(2020, 1, 1, hour, minute, tzinfo=ZoneInfo(self._schedule_timezone))
+        return IntervalTrigger(seconds=seconds, start_date=start, timezone=self._schedule_timezone)
+
+    def _instrument_task(self, job_id: str, func: Callable[..., Any], *, maintenance=False) -> Callable[..., Any]:
+        def _execute(*args, **kwargs):
             state = self._ensure_task_state(job_id)
             with self._state_lock:
                 state["status"] = "running"
@@ -137,19 +173,54 @@ class TaskService:
                 with self._state_lock:
                     state["status"] = "error"
                     state["next_run"] = next_run
-                    state["last_error"] = str(exc)
+                    state["last_error"] = self._error_message(exc)
                     state["last_result"] = None
                 self.persist_current_state(job_id, state)
                 self.logger.exception("Scheduled task failed task=%s error=%s", job_id, exc)
                 raise
 
+        def _runner(*args, **kwargs):
+            if not maintenance:
+                return _execute(*args, **kwargs)
+            ticket = object()
+            state = self._ensure_task_state(job_id)
+            with self._maintenance_condition:
+                self._maintenance_queue.append(ticket)
+                with self._state_lock:
+                    state["status"] = "waiting"
+                while self._maintenance_queue[0] is not ticket:
+                    if self.shutdown_event.is_set():
+                        self._maintenance_queue.remove(ticket)
+                        with self._state_lock:
+                            state["status"] = "interrupted"
+                        return None
+                    self._maintenance_condition.wait(timeout=0.25)
+            try:
+                if self.shutdown_event.is_set():
+                    with self._state_lock:
+                        state["status"] = "interrupted"
+                    return None
+                return _execute(*args, **kwargs)
+            finally:
+                with self._maintenance_condition:
+                    self._maintenance_queue.popleft()
+                    self._maintenance_condition.notify_all()
+
         return _runner
 
+    @staticmethod
+    def _error_message(exc: Exception) -> str:
+        from app.config.database_retry import is_database_locked
+        if is_database_locked(exc):
+            return "Database is busy. This run could not save its changes; try again after other work finishes."
+        return str(exc)
+
     def add_interval_task(self, func, seconds, job_id, args=None, kwargs=None):
+        self._interval_seconds[job_id] = seconds
         self._ensure_task_state(job_id, interval_seconds=seconds)
         self.scheduler.add_job(
-            self._instrument_task(job_id, func),
-            trigger=IntervalTrigger(seconds=seconds),
+            self._instrument_task(job_id, func, maintenance=True),
+            trigger=self._interval_trigger(job_id, seconds),
             id=job_id,
             args=args or [],
             kwargs=kwargs or {},
@@ -167,7 +238,8 @@ class TaskService:
         job = self.scheduler.get_job(job_id)
         if job is None:
             return False
-        self.scheduler.reschedule_job(job_id, trigger=IntervalTrigger(seconds=seconds))
+        self._interval_seconds[job_id] = seconds
+        self.scheduler.reschedule_job(job_id, trigger=self._interval_trigger(job_id, seconds))
         state = self._ensure_task_state(job_id, interval_seconds=seconds)
         with self._state_lock:
             state["interval_seconds"] = seconds
@@ -208,7 +280,7 @@ class TaskService:
         - "unavailable": the scheduler is not running or the job is not registered.
         """
         state = self.get_task_state(job_id)
-        if state and state.get("status") == "running":
+        if state and state.get("status") in {"running", "waiting"}:
             return "already_running"
         if not self.scheduler.running:
             return "unavailable"
@@ -236,9 +308,12 @@ class TaskService:
 
     def persist_current_state(self, job_id, state):
         # An older overlapping manual run must not overwrite the latest run.
-        with self._state_lock:
-            if self._task_states.get(job_id) is state:
-                self._persist_state(state)
+        # Keep database waits outside the state lock so Overview stays responsive.
+        with self._persist_lock:
+            with self._state_lock:
+                snapshot = dict(state) if self._task_states.get(job_id) is state else None
+            if snapshot is not None:
+                self._persist_state(snapshot)
 
     def get_jobs(self):
         return self.scheduler.get_jobs()

--- a/backend/app/tasks/channel_status_task.py
+++ b/backend/app/tasks/channel_status_task.py
@@ -18,7 +18,8 @@ def run_channel_status_task():
         service = ChannelStatusService(db)
         if not service._get_engine_url():
             return {"checked": 0, "skipped": 0, "failed": 0, "message": "No engine configured; status checks are disabled."}
-        channels = db.query(AcestreamChannel).filter(AcestreamChannel.is_active == True).all()
+        channels = [row[0] for row in db.query(AcestreamChannel.id).filter(AcestreamChannel.is_active == True).all()]
+        db.rollback()
         logger.info(f"Starting channel status update for {len(channels)} channels.")
 
         async def check_all():
@@ -26,10 +27,16 @@ def run_channel_status_task():
             skipped = 0
             checked = 0
             failed = 0
-            for channel in channels:
+            online = 0
+            offline = 0
+            for channel_id in channels:
                 if task_service.shutdown_event.is_set():
                     break
                 try:
+                    channel = db.get(AcestreamChannel, channel_id)
+                    if channel is None:
+                        skipped += 1
+                        continue
                     result = await service.check_channel_status(
                         channel, priority=ProbePriority.BACKGROUND, scan_started_at=started,
                     )
@@ -37,10 +44,23 @@ def run_channel_status_task():
                         skipped += 1
                     else:
                         checked += 1
+                        if result["is_online"]:
+                            online += 1
+                        else:
+                            offline += 1
                 except Exception as exc:
                     failed += 1
-                    logger.exception("Channel status check failed channel_id=%s error=%s", channel.id, exc)
+                    db.rollback()
+                    logger.exception("Channel status check failed channel_id=%s error=%s", channel_id, exc)
+                finally:
+                    db.rollback()
+                    task_service.update_task_progress("channel_status", {
+                        "processed": checked + skipped + failed, "total": len(channels),
+                        "percent": round(100 * (checked + skipped + failed) / len(channels), 1),
+                    })
             return {
+                "online": online,
+                "offline": offline,
                 "checked": checked,
                 "skipped": skipped,
                 "failed": failed,

--- a/backend/app/tasks/url_scraping_task.py
+++ b/backend/app/tasks/url_scraping_task.py
@@ -12,28 +12,30 @@ def run_url_scraping_task():
     logger = logging.getLogger("url_scraping_task")
     try:
         service = ScraperService(db)
-        enabled_urls = service.get_enabled_urls()
+        enabled_urls = [(row.url, row.url_type) for row in service.get_enabled_urls()]
+        db.rollback()
         logger.info(f"Starting URL scraping task for {len(enabled_urls)} URLs.")
 
         async def scrape_all():
             processed = 0
             failures = 0
-            for url_obj in enabled_urls:
+            for url, url_type in enabled_urls:
                 try:
-                    channels, status = await service.scrape_url(url_obj.url, url_obj.url_type)
+                    channels, status = await service.scrape_url(url, url_type)
                     processed += 1
                     if status.lower().startswith("error"):
                         failures += 1
                     logger.info(
                         "Scraped %s (type: %s): %s, channels found: %s",
-                        url_obj.url,
-                        url_obj.url_type,
+                        url,
+                        url_type,
                         status,
                         len(channels),
                     )
                 except Exception as exc:
                     failures += 1
-                    logger.exception("Failed scraping url=%s type=%s error=%s", url_obj.url, url_obj.url_type, exc)
+                    db.rollback()
+                    logger.exception("Failed scraping url=%s type=%s error=%s", url, url_type, exc)
             return {
                 "processed": processed,
                 "failures": failures,

--- a/backend/main.py
+++ b/backend/main.py
@@ -220,6 +220,8 @@ async def lifespan(app: FastAPI):
             startup_service.record('Starting background services')
             services_started = True
             await asyncio.to_thread(task_service.restore_states)
+            from app.services.schedule_config_service import load_schedule_anchors
+            task_service.configure_schedule(await asyncio.to_thread(load_schedule_anchors))
             task_service.start()
             task_service.add_interval_task(run_activity_log_cleanup, seconds=86400, job_id="activity_log_cleanup")  # daily
             scrape_hours, epg_hours, status_minutes = await asyncio.to_thread(_configured_intervals)

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3850,6 +3850,56 @@
         "title": "ScanResultResponse",
         "type": "object"
       },
+      "ScheduleAnchors": {
+        "description": "Optional clock anchors for the existing repeat intervals.",
+        "properties": {
+          "channel_status": {
+            "anyOf": [
+              {
+                "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Channel Status"
+          },
+          "epg_refresh": {
+            "anyOf": [
+              {
+                "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Epg Refresh"
+          },
+          "timezone": {
+            "default": "UTC",
+            "description": "IANA timezone used to interpret start times",
+            "title": "Timezone",
+            "type": "string"
+          },
+          "url_scraping": {
+            "anyOf": [
+              {
+                "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "HH:MM anchor; null retains startup-relative scheduling",
+            "title": "Url Scraping"
+          }
+        },
+        "title": "ScheduleAnchors",
+        "type": "object"
+      },
       "ScraperRequest": {
         "description": "Request model for scraping a URL",
         "properties": {
@@ -9033,6 +9083,68 @@
           }
         },
         "summary": "Update Rescrape Interval",
+        "tags": [
+          "config",
+          "config"
+        ]
+      }
+    },
+    "/api/v1/config/schedule-anchors": {
+      "get": {
+        "operationId": "get_schedule_anchors_api_v1_config_schedule_anchors_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleAnchors"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Schedule Anchors",
+        "tags": [
+          "config",
+          "config"
+        ]
+      },
+      "put": {
+        "operationId": "update_schedule_anchors_api_v1_config_schedule_anchors_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleAnchors"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScheduleAnchors"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Schedule Anchors",
         "tags": [
           "config",
           "config"

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -331,7 +331,7 @@ def test_scheduled_status_scan_has_no_hundred_channel_limit(db_session, monkeypa
     monkeypatch.setattr(task.ChannelStatusService, 'check_channel_status', check)
     result = task.run_channel_status_task()
     assert check.call_count == 151
-    assert result == {'checked': 0, 'skipped': 151, 'failed': 0}
+    assert result == {'checked': 0, 'skipped': 151, 'failed': 0, 'online': 0, 'offline': 0}
 
 
 def test_retired_manual_status_is_not_exposed(monkeypatch):

--- a/backend/tests/test_probe_queue.py
+++ b/backend/tests/test_probe_queue.py
@@ -214,6 +214,6 @@ def test_scheduled_task_uses_background_priority_and_counts_skips(alembic_db_ses
     probe = AsyncMock(return_value={'status': 'skipped'})
     monkeypatch.setattr(channel_status_task.ChannelStatusService, 'check_channel_status', probe)
     result = channel_status_task.run_channel_status_task()
-    assert result == {'checked': 0, 'skipped': 1, 'failed': 0}
+    assert result == {'checked': 0, 'skipped': 1, 'failed': 0, 'online': 0, 'offline': 0}
     assert probe.call_args.kwargs['priority'] == ProbePriority.BACKGROUND
     assert probe.call_args.kwargs['scan_started_at'].tzinfo is not None

--- a/backend/tests/test_schedule_reliability.py
+++ b/backend/tests/test_schedule_reliability.py
@@ -1,0 +1,208 @@
+"""Concurrency and user-facing schedule contracts."""
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from datetime import datetime, timezone
+import sqlite3
+import time
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+
+from app.schemas.config import ScheduleAnchors
+from app.services.task_service import TaskService
+
+
+def test_due_jobs_wait_in_order_and_failure_releases_queue():
+    service = TaskService()
+    entered = Event()
+    release = Event()
+    calls = []
+
+    def first():
+        entered.set()
+        assert release.wait(3)
+        calls.append('first')
+        raise ValueError('failed')
+
+    def second():
+        calls.append('second')
+        return 2
+
+    with ThreadPoolExecutor(2) as pool:
+        one = pool.submit(service._instrument_task('epg_refresh', first, maintenance=True))
+        assert entered.wait(2)
+        two = pool.submit(service._instrument_task('url_scraping', second, maintenance=True))
+        deadline = time.monotonic() + 2
+        while not service.get_task_state('url_scraping') and time.monotonic() < deadline:
+            time.sleep(.01)
+        try:
+            state = service.get_task_state('url_scraping')
+            assert state['status'] == 'waiting'
+            assert state['last_run'] is None
+            assert service.run_task_now('url_scraping') == 'already_running'
+            assert not calls
+        finally:
+            release.set()
+        with pytest.raises(ValueError):
+            one.result(3)
+        assert two.result(3) == 2
+    assert calls == ['first', 'second']
+
+
+def test_clock_schedule_survives_restart_and_interval_changes():
+    schedule = ScheduleAnchors(timezone='Europe/Madrid', url_scraping='03:15')
+    now = datetime(2026, 9, 10, 0, 0, tzinfo=timezone.utc)
+    for _ in range(2):
+        service = TaskService()
+        service.configure_schedule(schedule)
+        trigger = service._interval_trigger('url_scraping', 6 * 3600)
+        assert trigger.get_next_fire_time(None, now).isoformat() == '2026-09-10T03:15:00+02:00'
+        winter = datetime(2026, 12, 10, 0, 0, tzinfo=timezone.utc)
+        assert trigger.get_next_fire_time(None, winter).isoformat() == '2026-12-10T03:15:00+01:00'
+        service.add_interval_task(lambda: None, 3600, 'url_scraping')
+        service.configure_schedule(schedule)
+        assert service.reschedule_task('url_scraping', 2 * 3600)
+        assert service.scheduler.get_job('url_scraping').trigger.get_next_fire_time(None, now).hour == 3
+
+
+def test_schedule_api_roundtrip_and_validation(client):
+    payload = {'timezone': 'Europe/Madrid', 'url_scraping': '03:15', 'epg_refresh': '02:00', 'channel_status': '03:30'}
+    assert client.put('/api/v1/config/schedule-anchors', json=payload).status_code == 200
+    assert client.get('/api/v1/config/schedule-anchors').json() == payload
+    for key, value in [('timezone', 'Invalid/Zone'), ('url_scraping', '25:00'), ('channel_status', '3:00')]:
+        assert client.put('/api/v1/config/schedule-anchors', json={**payload, key: value}).status_code == 422
+    assert client.get('/api/v1/config/schedule-anchors').json() == payload
+
+
+def test_status_write_retries_real_sqlite_lock_then_session_is_usable(alembic_db_session, monkeypatch):
+    from app.models.models import AcestreamChannel
+    from app.repositories.channel_repository import ChannelRepository
+    from app.config import database_retry
+    db_session = alembic_db_session
+    channel_id = 'a' * 40
+    db_session.add(AcestreamChannel(id=channel_id, name='Test', is_active=True))
+    db_session.commit()
+    # Separate connection owns a real write lock. Release it at retry backoff.
+    engine = db_session.get_bind()
+    with engine.connect() as holder:
+        holder.execute(text('UPDATE acestream_channels SET name=name WHERE id=:id'), {'id': channel_id})
+        db_session.execute(text('PRAGMA busy_timeout=1'))
+        retries = []
+        def release(_):
+            retries.append(True)
+            holder.rollback()
+        monkeypatch.setattr(database_retry.time, 'sleep', release)
+        ChannelRepository(db_session).update_channel_status(channel_id, False)
+    assert len(retries) == 1
+    assert db_session.get(AcestreamChannel, channel_id).is_online is False
+
+
+def test_non_lock_failure_is_not_retried_and_rolls_back(db_session, monkeypatch):
+    from app.repositories.channel_repository import ChannelRepository
+    calls = []
+    def fail(*args):
+        calls.append(1)
+        raise OperationalError('query', {}, sqlite3.OperationalError('no such table'))
+    repository = ChannelRepository(db_session)
+    monkeypatch.setattr(repository, 'get_channel_by_id', fail)
+    with pytest.raises(OperationalError):
+        repository.update_channel_status('a' * 40, False)
+    assert len(calls) == 1
+    assert db_session.execute(text('SELECT 1')).scalar() == 1
+
+
+def test_scan_counts_outcomes_and_continues_after_failed_flush(alembic_db_session, monkeypatch):
+    from app.tasks import channel_status_task as task
+    from app.models.models import AcestreamChannel
+    from app.repositories.settings_repository import SettingsRepository
+    db = alembic_db_session
+    SettingsRepository(db).set_setting('ace_engine_url', 'http://engine.test:6878')
+    for i in range(4):
+        db.add(AcestreamChannel(id=f'{i:040x}', name=f'Stream {i}', is_active=True))
+    db.commit()
+    monkeypatch.setattr(task, 'SessionLocal', lambda: db)
+    monkeypatch.setattr(task.task_service, 'shutdown_event', Event())
+    calls = []
+    async def check(self, channel, **kwargs):
+        i = len(calls)
+        calls.append(channel.id)
+        if i == 0:
+            db.add(AcestreamChannel(id=channel.id, name="Duplicate"))  # Real flush failure.
+            db.flush()
+        if i == 1:
+            return {'status': 'online', 'is_online': True}
+        if i == 2:
+            return {'status': 'offline', 'is_online': False}
+        return {'status': 'skipped', 'is_online': False}
+    monkeypatch.setattr(task.ChannelStatusService, 'check_channel_status', check)
+    assert task.run_channel_status_task() == {'checked': 2, 'online': 1, 'offline': 1, 'skipped': 1, 'failed': 1}
+    assert len(calls) == 4
+
+
+def test_repeat_epg_parse_does_not_hold_writer_lock(alembic_db_session, monkeypatch):
+    from app.models.models import EPGSource, EPGChannel
+    from app.services.epg_service import EPGService
+    db = alembic_db_session
+    source = EPGSource(name='Test', url='https://example.test/epg.xml', enabled=True)
+    db.add(source)
+    db.commit()
+    source_id = source.id
+    db.add(EPGChannel(epg_source_id=source_id, channel_xml_id='test', name='Test'))
+    db.commit()
+    service = EPGService(db)
+    parse = service._parse_xmltv_time
+    observed = []
+    def parse_while_another_writer_runs(value):
+        with db.get_bind().begin() as connection:
+            connection.execute(text('PRAGMA busy_timeout=1'))
+            connection.execute(text('UPDATE epg_sources SET name=name WHERE id=:id'), {'id': source_id})
+            observed.append(True)
+        return parse(value)
+    monkeypatch.setattr(service, '_parse_xmltv_time', parse_while_another_writer_runs)
+    service._process_epg_xml(source_id, b'<tv><channel id="test"><display-name>Updated</display-name></channel><programme channel="test" start="20260910080000 +0000" stop="20260910090000 +0000"><title>News</title></programme></tv>')
+    assert len(observed) == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelling_database_await_keeps_session_owned_until_worker_finishes():
+    import asyncio
+    from app.config.database_retry import run_database_write
+    entered = Event()
+    release = Event()
+    closed = []
+    def write():
+        entered.set()
+        assert release.wait(2)
+        assert not closed
+    async def caller():
+        try:
+            await run_database_write(write)
+        finally:
+            closed.append(True)
+    operation = asyncio.create_task(caller())
+    while not entered.is_set():
+        await asyncio.sleep(.01)
+    operation.cancel()
+    await asyncio.sleep(.01)
+    assert not closed
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await operation
+    assert closed == [True]
+
+
+def test_lock_retries_are_bounded(db_session, monkeypatch):
+    from app.repositories.channel_repository import ChannelRepository
+    from app.config import database_retry
+    repository = ChannelRepository(db_session)
+    attempts = []
+    def fail(*args):
+        attempts.append(True)
+        raise OperationalError('query', {}, sqlite3.OperationalError('database is locked'))
+    monkeypatch.setattr(repository, 'get_channel_by_id', fail)
+    monkeypatch.setattr(database_retry.time, 'sleep', lambda _: None)
+    with pytest.raises(OperationalError):
+        repository.update_channel_status('a' * 40, False)
+    assert len(attempts) == 3
+    assert db_session.is_active

--- a/docs/ops/scheduled-job-history.md
+++ b/docs/ops/scheduled-job-history.md
@@ -34,3 +34,43 @@ retain their interactive probe priority and safety guards.
 The former `/channels/check_status_all` and `/acestream-channels/check_status_all`
 manual bulk endpoints are removed. Historical `manual_channel_status` records are
 retained in storage but no longer shown in task status responses.
+
+### Start times and overlapping work
+
+Settings → Automation retains the existing repeat intervals and adds optional
+start times for scraping, EPG refresh and stream checks, with an IANA timezone
+(e.g. `Europe/Madrid`). `GET/PUT /api/v1/config/schedule-anchors` saves all three
+anchors and the timezone together in the existing settings table. Blank times
+preserve startup-relative intervals; configuring a time applies immediately and
+survives restarts. Saving does not launch an immediate catch-up run.
+
+For hour intervals dividing 24, runs follow the local clock: 03:15 every six
+hours means 03:15, 09:15, 15:15 and 21:15. Minute intervals dividing 60 repeat
+at the selected minute offset each hour. These use calendar triggers; DST can
+skip or repeat a local occurrence. Other intervals use elapsed time from the
+stable anchor date 2020-01-01 in the selected timezone, so local times can shift
+with DST. Overview reports the scheduler's actual next occurrence.
+
+All recurring maintenance jobs, including scheduler “run now” requests, share a
+FIFO execution queue. A due job displays **Waiting** until earlier work finishes;
+its last-started time changes only when it actually starts. Repeated occurrences
+of an already running/waiting job do not accumulate additional runs. Staggering
+start times reduces waiting but is not the overlap guarantee. A long stream scan
+can delay the other maintenance jobs. Interactive playback probes and separately
+tracked manual actions retain their existing behavior and are outside this queue.
+
+Repeat EPG imports defer the initial flush when no new channel IDs are needed,
+so parsing and comparing the programme inventory does not hold the writer lock.
+Stream status and scrape-status writes retry SQLite lock failures up to three
+attempts, rolling back and replaying the database operation. Their blocking writes
+and retry delays run off the async event loop. Failed scraper/check sessions are
+rolled back before reuse; inventory identifiers are copied before processing so
+error logging cannot reload objects through a failed session.
+
+Stream-check results now distinguish **checked, online, offline, skipped and
+errors**. Checked is online + offline, not the full catalogue size. Skipped
+includes recently checked/in-use streams and unavailable engines, whose previous
+status is preserved. Errors count exceptions, not offline streams. Older saved
+results lack online/offline totals, so Overview shows their known counts without
+inventing an offline count. Progress shows how much of the active inventory has
+been processed.

--- a/e2e/mobile/schedule.spec.ts
+++ b/e2e/mobile/schedule.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+for (const mode of ['light', 'dark']) {
+  test(`${mode}: schedule start times save and survive reload`, async ({ page }) => {
+    let anchors = { timezone: 'UTC', url_scraping: null as string | null, epg_refresh: null as string | null, channel_status: null as string | null };
+    const errors: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    page.on('console', message => { if (message.type() === 'error') errors.push(message.text()); });
+    page.on('response', response => { if (response.url().includes('/api/') && response.status() >= 400) errors.push(`${response.status()} ${response.url()}`); });
+    await page.route('**/api/**', async route => {
+      const path = new URL(route.request().url()).pathname.replace('/api/v1', '');
+      let data: unknown = {};
+      if (path === '/startup') data = { status: 'ready', phase: 'Ready to use', events: [] };
+      else if (path === '/config/schedule-anchors') {
+        if (route.request().method() === 'PUT') anchors = route.request().postDataJSON();
+        data = anchors;
+      } else if (path === '/config/check-engine') data = { use_dedicated: false, url: '', managed: false };
+      else if (path === '/config/playback-routing') data = { use_acexy: false, acexy_url: 'http://localhost:8080' };
+      else if (path === '/config/acestream_status') data = { status: 'online', message: 'Engine online' };
+      else if (path === '/config/rescrape_interval' || path === '/config/epg_refresh_interval') data = { value: '6' };
+      else if (path === '/config/channel_status_interval') data = { value: '60' };
+      else if (path.startsWith('/config/')) data = { value: 'false' };
+      else if (path === '/base-urls') data = [];
+      await route.fulfill({ json: data });
+    });
+    await page.addInitScript(value => localStorage.setItem('app-theme-mode', value), mode);
+    await page.goto('/settings?tab=automation');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('form', { name: 'Schedule start times', exact: true })).toBeVisible();
+    await page.getByRole('textbox', { name: 'Schedule timezone' }).fill('Europe/Madrid');
+    await page.getByLabel('Scrape sources start time').fill('03:15');
+    await page.getByLabel('EPG refresh start time').fill('02:00');
+    await page.getByLabel('Stream checks start time').fill('03:30');
+    await page.getByRole('button', { name: 'Save start times' }).click();
+    await expect(page.getByText('Schedule start times saved.')).toBeVisible();
+    expect(anchors).toEqual({ timezone: 'Europe/Madrid', url_scraping: '03:15', epg_refresh: '02:00', channel_status: '03:30' });
+    await page.reload();
+    await expect(page.getByLabel('Scrape sources start time')).toHaveValue('03:15');
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+    await page.screenshot({ path: test.info().outputPath(`schedule-${mode}.png`), fullPage: true });
+    expect(errors).toEqual([]);
+  });
+}

--- a/frontend/src/__tests__/ScheduleAnchorFields.test.tsx
+++ b/frontend/src/__tests__/ScheduleAnchorFields.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ScheduleAnchorFields from '../components/ScheduleAnchorFields';
+import { getScheduleAnchors, saveScheduleAnchors } from '../services/configService';
+
+jest.mock('../services/configService', () => ({ getScheduleAnchors: jest.fn(), saveScheduleAnchors: jest.fn() }));
+const initial = { timezone: 'UTC', url_scraping: null, epg_refresh: null, channel_status: null };
+const renderFields = () => render(<QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}><ScheduleAnchorFields /></QueryClientProvider>);
+
+beforeEach(() => jest.resetAllMocks());
+
+it('loads, edits and saves anchors without changing intervals', async () => {
+  (getScheduleAnchors as jest.Mock).mockResolvedValue(initial);
+  (saveScheduleAnchors as jest.Mock).mockImplementation(async value => value);
+  renderFields();
+  const timezone = await screen.findByLabelText(/Schedule timezone/);
+  fireEvent.change(timezone, { target: { value: 'Europe/Madrid' } });
+  fireEvent.change(screen.getByLabelText('Scrape sources start time'), { target: { value: '03:15' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save start times' }));
+  expect(await screen.findByText('Schedule start times saved.')).toBeInTheDocument();
+  expect(saveScheduleAnchors).toHaveBeenCalledWith({ ...initial, timezone: 'Europe/Madrid', url_scraping: '03:15' }, expect.anything());
+  fireEvent.change(screen.getByLabelText('Scrape sources start time'), { target: { value: '' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save start times' }));
+  await waitFor(() => expect(saveScheduleAnchors).toHaveBeenLastCalledWith({ ...initial, timezone: 'Europe/Madrid' }, expect.anything()));
+});
+
+it('shows a load error and allows retry', async () => {
+  (getScheduleAnchors as jest.Mock).mockRejectedValueOnce(new Error('Unavailable')).mockResolvedValue(initial);
+  renderFields();
+  fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+  expect(await screen.findByLabelText(/Schedule timezone/)).toHaveValue('UTC');
+});
+
+it('keeps the draft after a failed save', async () => {
+  (getScheduleAnchors as jest.Mock).mockResolvedValue(initial);
+  (saveScheduleAnchors as jest.Mock).mockRejectedValue(new Error('Cannot save'));
+  renderFields();
+  fireEvent.change(await screen.findByLabelText(/Schedule timezone/), { target: { value: 'Europe/Madrid' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save start times' }));
+  expect(await screen.findByRole('alert')).toHaveTextContent('Something went wrong. Try again.');
+  expect(screen.getByLabelText(/Schedule timezone/)).toHaveValue('Europe/Madrid');
+});

--- a/frontend/src/__tests__/ScheduledJobs.test.tsx
+++ b/frontend/src/__tests__/ScheduledJobs.test.tsx
@@ -32,3 +32,21 @@ test('keeps manual results separate from scheduled next-run time', () => {
   expect(within(manualRow).getByText('—')).toBeInTheDocument();
   expect(screen.getByText('2 sources refreshed')).toBeInTheDocument();
 });
+
+const statusTask: BackgroundTaskStatus = {
+  task_name: 'channel_status', status: 'idle', last_run: '2026-09-10T07:00:00Z',
+  next_run: '2026-09-10T08:00:00Z', last_error: null,
+  last_result: { checked: 10, online: 7, offline: 3, skipped: 2, failed: 1 },
+};
+
+it('shows actual offline results separately from check errors', () => {
+  render(<ScheduledJobs tasks={[statusTask]} />);
+  expect(screen.getByText('10 checked, 7 online, 3 offline, 2 skipped, 1 error')).toBeInTheDocument();
+});
+
+it('shows a queued run as waiting instead of displaying its previous error', () => {
+  render(<ScheduledJobs tasks={[{ ...statusTask, status: 'waiting', last_error: 'Previous failure' }]} />);
+  expect(screen.getByText('Waiting for another maintenance job')).toBeInTheDocument();
+  expect(screen.getByText('Waiting')).toBeInTheDocument();
+  expect(screen.queryByText('Previous failure')).not.toBeInTheDocument();
+});

--- a/frontend/src/__tests__/Settings.test.tsx
+++ b/frontend/src/__tests__/Settings.test.tsx
@@ -20,6 +20,8 @@ jest.mock('../hooks/useConfig');
 jest.mock('../hooks/useBaseUrls');
 jest.mock('../services/configService', () => ({
   configService: { getAppId: jest.fn(), updateAppId: jest.fn() },
+  getScheduleAnchors: jest.fn().mockResolvedValue({ timezone: 'UTC', url_scraping: null, epg_refresh: null, channel_status: null }),
+  saveScheduleAnchors: jest.fn(),
 }));
 
 type MutateOptions = { onSuccess?: () => void; onError?: (error: unknown) => void };

--- a/frontend/src/__tests__/format.test.ts
+++ b/frontend/src/__tests__/format.test.ts
@@ -35,7 +35,8 @@ describe('job names and results', () => {
   });
   it('summarises last results per job', () => {
     expect(summarizeJobResult('url_scraping', { processed: 2, failures: 0 })).toBe('2 sources, 0 errors');
-    expect(summarizeJobResult('channel_status', { checked: 6, failed: 5 })).toBe('6 checked, 5 offline');
+    expect(summarizeJobResult('channel_status', { checked: 6, failed: 5 })).toBe('6 checked, 0 skipped, 5 errors');
+    expect(summarizeJobResult('channel_status', { checked: 6, online: 2, offline: 4, skipped: 3, failed: 1 })).toBe('6 checked, 2 online, 4 offline, 3 skipped, 1 error');
     expect(summarizeJobResult('epg_refresh', { sources: 1, successful: 1, failed: 0 })).toBe('1 source refreshed');
     expect(summarizeJobResult('epg_refresh', { sources: 2, successful: 1, failed: 1 })).toBe('1 of 2 sources refreshed, 1 failed');
     expect(summarizeJobResult('epg_program_cleanup', { deleted: 312, disabled: false })).toBe('312 programmes removed');

--- a/frontend/src/components/ScheduleAnchorFields.tsx
+++ b/frontend/src/components/ScheduleAnchorFields.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Alert, Button, LinearProgress, Stack, TextField, Typography } from '@mui/material';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getScheduleAnchors, saveScheduleAnchors, type ScheduleAnchors } from '../services/configService';
+import { getErrorMessage } from '../utils/errorUtils';
+
+const jobs = [
+  ['url_scraping', 'Scrape sources start time'],
+  ['epg_refresh', 'EPG refresh start time'],
+  ['channel_status', 'Stream checks start time'],
+] as const;
+
+export default function ScheduleAnchorFields() {
+  const client = useQueryClient();
+  const query = useQuery({ queryKey: ['scheduleAnchors'], queryFn: getScheduleAnchors });
+  const [draft, setDraft] = useState<ScheduleAnchors | null>(null);
+  const save = useMutation({ mutationFn: saveScheduleAnchors, onSuccess: data => {
+    client.setQueryData(['scheduleAnchors'], data);
+    void client.invalidateQueries({ queryKey: ['dashboard-background-tasks'] });
+    setDraft(null);
+  } });
+  const config = draft ?? query.data;
+  if (query.isLoading) return <LinearProgress aria-label="Loading schedule start times" />;
+  if (query.isError || !config) return <Alert severity="error" action={<Button onClick={() => void query.refetch()}>Retry</Button>}>Unable to load schedule start times.</Alert>;
+  const change = (value: Partial<ScheduleAnchors>) => { setDraft({ ...config, ...value }); save.reset(); };
+  return <Stack component="form" aria-label="Schedule start times" spacing={2} onSubmit={(event: React.FormEvent) => {
+    event.preventDefault();
+    save.mutate(config);
+  }}>
+    <Typography variant="subtitle2">Schedule start times</Typography>
+    <Typography variant="body2" color="text.secondary">Jobs repeat at the intervals above. Leave a start time blank to count from application startup. Due maintenance jobs wait their turn, so a long run can delay the next job.</Typography>
+    <TextField label="Schedule timezone" size="small" required value={config.timezone} onChange={event => change({ timezone: event.target.value })} disabled={save.isPending} helperText="For example: Europe/Madrid or UTC. Intervals that divide evenly into an hour or day keep local clock times. Other intervals use elapsed time and can shift with daylight saving." />
+    <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+      {jobs.map(([key, label]) => <TextField key={key} label={label} type="time" size="small" value={config[key] ?? ''} disabled={save.isPending} InputLabelProps={{ shrink: true }} onChange={event => change({ [key]: event.target.value || null })} sx={theme => ({ flex: 1, colorScheme: theme.palette.mode })} />)}
+    </Stack>
+    {save.isError && <Alert severity="error">{getErrorMessage(save.error)}</Alert>}
+    {save.isSuccess && <Alert severity="success">Schedule start times saved.</Alert>}
+    <Button type="submit" variant="outlined" disabled={!draft || save.isPending} sx={{ alignSelf: 'flex-start' }}>{save.isPending ? 'Saving…' : 'Save start times'}</Button>
+  </Stack>;
+}

--- a/frontend/src/components/overview/ScheduledJobs.tsx
+++ b/frontend/src/components/overview/ScheduledJobs.tsx
@@ -9,6 +9,8 @@ const ORDER = ['url_scraping', 'channel_status', 'epg_refresh', 'epg_program_cle
 
 const statusChip = (status: string) => {
   switch (status) {
+    case 'waiting':
+      return <Chip size="small" color="warning" label="Waiting" />;
     case 'running':
       return <Chip size="small" color="info" label="Running" />;
     case 'interrupted':
@@ -60,7 +62,7 @@ const ScheduledJobs: React.FC<ScheduledJobsProps> = ({ tasks }) => {
                 </Tooltip>
               </TableCell>
               <TableCell data-label="Result">
-                {task.last_error ? (
+                {task.status === 'waiting' ? <span>Waiting for another maintenance job</span> : task.last_error ? (
                   <Typography variant="body2" color="error.main">
                     {task.last_error}
                   </Typography>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,3 +1,4 @@
+import ScheduleAnchorFields from '../components/ScheduleAnchorFields';
 import StreamLinkFormatsSection from '../components/StreamLinkFormatsSection';
 import CheckEngineFields from '../components/CheckEngineFields';
 import React, { useEffect, useState } from 'react';
@@ -336,6 +337,7 @@ const Settings: React.FC = () => {
             onChange={setChannelStatusInterval}
             onSave={handleChannelStatusSave}
           />
+          <ScheduleAnchorFields />
 
         </Stack>
       </ContentSection>

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -210,3 +210,7 @@ export const configService = {
     return response.data;
   }
 };
+
+export type ScheduleAnchors = import('../types/api-generated').components['schemas']['ScheduleAnchors'];
+export const getScheduleAnchors = async (): Promise<ScheduleAnchors> => (await apiClient.get<ScheduleAnchors>(`${BASE_URL}/schedule-anchors`)).data;
+export const saveScheduleAnchors = async (schedule: ScheduleAnchors): Promise<ScheduleAnchors> => (await apiClient.put<ScheduleAnchors>(`${BASE_URL}/schedule-anchors`, schedule)).data;

--- a/frontend/src/types/api-generated.ts
+++ b/frontend/src/types/api-generated.ts
@@ -357,6 +357,12 @@ export interface paths {
      */
     put: operations["update_rescrape_interval_api_v1_config_rescrape_interval_put"];
   };
+  "/api/v1/config/schedule-anchors": {
+    /** Get Schedule Anchors */
+    get: operations["get_schedule_anchors_api_v1_config_schedule_anchors_get"];
+    /** Update Schedule Anchors */
+    put: operations["update_schedule_anchors_api_v1_config_schedule_anchors_put"];
+  };
   "/api/v1/config/{key}": {
     /**
      * Get Config Key
@@ -2580,6 +2586,27 @@ export interface components {
       hosts: components["schemas"]["ScanHitResponse"][];
       /** Scanned */
       scanned: number;
+    };
+    /**
+     * ScheduleAnchors
+     * @description Optional clock anchors for the existing repeat intervals.
+     */
+    ScheduleAnchors: {
+      /** Channel Status */
+      channel_status?: string | null;
+      /** Epg Refresh */
+      epg_refresh?: string | null;
+      /**
+       * Timezone
+       * @description IANA timezone used to interpret start times
+       * @default UTC
+       */
+      timezone?: string;
+      /**
+       * Url Scraping
+       * @description HH:MM anchor; null retains startup-relative scheduling
+       */
+      url_scraping?: string | null;
     };
     /**
      * ScraperRequest
@@ -4820,6 +4847,39 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["ConfigUpdateResponse"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Get Schedule Anchors */
+  get_schedule_anchors_api_v1_config_schedule_anchors_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ScheduleAnchors"];
+        };
+      };
+    };
+  };
+  /** Update Schedule Anchors */
+  update_schedule_anchors_api_v1_config_schedule_anchors_put: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ScheduleAnchors"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["ScheduleAnchors"];
         };
       };
       /** @description Validation Error */

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -62,7 +62,15 @@ export const summarizeJobResult = (id: string, result: unknown): string | null =
     case 'channel_status': {
       const checked = field(result, 'checked');
       const failed = field(result, 'failed') ?? 0;
-      return checked === null ? null : `${checked} checked, ${failed} offline`;
+      if (result && typeof result === 'object' && typeof (result as Record<string, unknown>).message === 'string') {
+        return (result as Record<string, string>).message;
+      }
+      if (checked === null) return null;
+      const online = field(result, 'online');
+      const offline = field(result, 'offline');
+      const skipped = field(result, 'skipped') ?? 0;
+      const counts = online !== null && offline !== null ? `, ${online} online, ${offline} offline` : '';
+      return `${checked} checked${counts}, ${skipped} skipped, ${plural(failed, 'error', 'errors')}`;
     }
     case 'epg_refresh': {
       const sources = field(result, 'sources');


### PR DESCRIPTION
## Scope

Scraping and stream checks could fail when scheduled maintenance jobs started together and contended with an EPG import for SQLite's writer lock. Failed sessions were then reused, producing secondary rollback errors. Overview also incorrectly labelled check exceptions as offline streams.

- Serialize recurring maintenance through a FIFO queue and show waiting jobs in Overview. Preserve interactive playback probes and separately tracked manual actions.
- Add optional start times and an IANA timezone in Settings → Automation, retaining the existing intervals and blank-time behavior. Persist the settings and regenerate the API client.
- Defer the early EPG flush for existing channels, retry bounded scrape-status and stream-status writes after rollback, and keep session ownership until database worker threads finish.
- Report actual online, offline, skipped and error counts, with scan progress and compatibility for older saved results.

## Risks

- Long stream scans can delay other scheduled maintenance. Manual actions remain outside this queue.
- Clock schedules follow local time for supported hour/minute divisors; other intervals use elapsed time. DST semantics are documented in `docs/ops/scheduled-job-history.md`.
- No schema migration, deployment or infrastructure changes. Reverting this PR restores the previous scheduling behavior; saved optional anchors can remain unused.

## Verification

- `CI_USE_PREINSTALLED_DEPS=1 bash scripts/ci/run_v2_test_suite.sh --profile quick` passed end to end, including the generated-client drift check.

- 260 focused backend tests passed, including real SQLite contention, failed-session recovery, queue ordering, cancellation and scheduling.
- Frontend tests cover schedule persistence, errors and corrected result labels; the existing dashboard-history tests are retained.
- Four Playwright checks passed across phone/desktop and light/dark themes, including save/reload and overflow checks.
- Frontend lint/typecheck, E2E typecheck, production build, byte-identical API regeneration and strict legacy-path guard passed.
